### PR TITLE
fix(deploy): run database migrations automatically on every deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -241,6 +241,24 @@ jobs:
             # Deploy full stack
             docker compose up -d --remove-orphans
             
+            # Run database migrations (all are idempotent via IF NOT EXISTS)
+            echo "⏳ Waiting for postgres to be ready..."
+            for i in {1..15}; do
+              if docker exec daon-postgres pg_isready -U daon_api -d daon_production -q; then
+                echo "✅ Postgres is ready"
+                break
+              fi
+              echo "Attempt $i/15, waiting 5s..."
+              sleep 5
+            done
+
+            echo "🗄️ Running database migrations..."
+            for migration in /opt/daon-source/api-server/src/database/migrations/*.sql; do
+              echo "  → $(basename $migration)"
+              docker exec -i daon-postgres psql -U daon_api -d daon_production < "$migration"
+            done
+            echo "✅ Migrations complete"
+
             # Wait for health checks
             echo "⏳ Waiting for services to be healthy..."
             sleep 60


### PR DESCRIPTION
## Summary

- Migrations were not wired into the deploy pipeline — they had to be run manually after each deploy
- Added automatic migration runner to `deploy.yml` after `docker compose up`, before health checks
- Waits for postgres to report ready (`pg_isready`) before running
- Runs all `.sql` files in `migrations/` in glob order — all use `IF NOT EXISTS` so safe to re-run on every deploy

## Test plan

- [ ] Verify next deploy runs all 5 migrations without error
- [ ] Verify re-running an already-applied migration is a no-op (IF NOT EXISTS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)