### PR TITLE
fix(deploy): force-recreate containers so new images are always started

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -238,8 +238,8 @@ jobs:
             # Build blockchain image locally
             docker build -t daon-blockchain:latest ./daon-core
 
-            # Deploy full stack
-            docker compose up -d --remove-orphans
+            # Deploy full stack — force-recreate ensures new images are actually used
+            docker compose up -d --remove-orphans --force-recreate
             
             # Run database migrations (all are idempotent via IF NOT EXISTS)
             echo "⏳ Waiting for postgres to be ready..."


### PR DESCRIPTION
## Summary

- `docker compose up -d --remove-orphans` silently leaves containers in `Created` state if they already exist under the same name from a previous deploy
- This caused `daon-frontend` to be built but never started on the last deploy — `app.daon.network` returned 502 until manually started
- `--force-recreate` ensures all containers are stopped and restarted with the newly built images on every deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)