### PR TITLE
docs(creators): comprehensive embedding guide for all file formats

### DIFF
--- a/docs/creators/embedding-tokens.md
+++ b/docs/creators/embedding-tokens.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Embedding Your Verification Token"
-description: "Platform-specific instructions for adding your DAON verification token to your published work"
+description: "Complete guide to embedding your DAON verification token in every major file format and platform"
 ---
 
 # Embedding Your Verification Token
@@ -12,9 +12,54 @@ After registering your content, you'll receive a verification URL like:
 https://app.daon.network/verify/sha256:a3f9b2...
 ```
 
-This URL proves ownership — but only if readers can find it alongside your actual work. This guide shows you how to embed your verification token on each major platform.
+This URL proves ownership — but only if readers can find it alongside your actual work. This guide shows you how to embed your verification token everywhere it can go.
 
 > **Why this matters:** The verification link proves *a hash was registered*, not that the content you're reading *is* that registered work. To close that gap, embed the token in the content itself so readers can use the [Verify by Content tool](https://app.daon.network/verify) to confirm a match.
+
+---
+
+## What this protection is — and isn't
+
+Embedding your DAON token works like `robots.txt` combined with a timestamped legal receipt.
+
+`robots.txt` is a declared boundary. It tells crawlers "do not scrape this." Ethical crawlers respect it. Bad actors can ignore it — but ignoring a declared, machine-readable boundary is a deliberate choice, and courts are increasingly treating it as one.
+
+DAON gives you the same declared boundary, plus something `robots.txt` can't: **proof**. If a scraper ignores your meta tags and uses your work anyway, you have a cryptographic, timestamped record proving the content existed, was owned by you, and was licensed with explicit AI training restrictions — before the scraping happened.
+
+That record is what makes the boundary meaningful in a legal context. The more places your token appears, the harder it is to claim the boundary wasn't visible.
+
+**Embed everywhere you can.**
+
+---
+
+## ⚠️ The metadata stripping problem
+
+Most social platforms (Instagram, Twitter/X, Facebook, TikTok, Discord) **strip all EXIF and metadata from images and videos on upload**. Your carefully embedded ExifTool data will not survive posting to these platforms.
+
+For those platforms, the only reliable embedding is in the visible text of a post, caption, or bio. See [Social Media](#social-media) below.
+
+For files you distribute directly — on your own site, via email, as downloads — metadata embedding works and travels with the file.
+
+---
+
+## Contents
+
+- [Web Pages](#web-pages-full-spec)
+- [Images](#images)
+- [Video](#video)
+- [Audio](#audio)
+- [PDF Documents](#pdf-documents)
+- [Word / DOCX](#word--docx)
+- [LibreOffice / ODT](#libreoffice--odt)
+- [EPUB](#epub)
+- [SVG](#svg)
+- [Source Code](#source-code)
+- [Plain Text and Markdown](#plain-text-and-markdown)
+- [XMP Sidecar Files](#xmp-sidecar-files)
+- [Platform-Specific: AO3, Wattpad, Fanfiction.Net](#ao3--wattpad--fanfictionnet)
+- [Platform-Specific: WordPress](#wordpress--self-hosted-blog)
+- [Platform-Specific: Social Media](#social-media)
+- [Declaring Boundaries for AI Crawlers](#declaring-boundaries-for-ai-crawlers)
 
 ---
 
@@ -52,11 +97,532 @@ For any page you control, the complete embedding pattern uses two `<meta>` tags 
 
 ---
 
-## Platform-Specific Instructions
+## Images
 
-### WordPress / Self-Hosted Blog
+### The stripping warning, again
 
-Add both the machine-readable tags and a visible badge.
+If you're uploading to a social platform: **metadata will be stripped**. Embed in visible text instead. If you're distributing the file directly, metadata embedding is reliable.
+
+### JPEG, TIFF — ExifTool (command line)
+
+[ExifTool](https://exiftool.org/) is the most reliable cross-platform tool for embedding metadata into image files. Install it from [exiftool.org](https://exiftool.org/) or via your package manager (`brew install exiftool`, `apt install libimage-exiftool-perl`).
+
+```bash
+exiftool \
+  -Comment="DAON:sha256:YOUR_HASH_HERE" \
+  -Copyright="© YOUR_NAME. Registered on DAON. Verify: https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  -XMP-dc:Rights="https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  -IPTC:CopyrightNotice="DAON:sha256:YOUR_HASH_HERE" \
+  -XMP-xmpRights:WebStatement="https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  -XMP-xmpRights:Marked=True \
+  your-image.jpg
+```
+
+Verify it was written:
+```bash
+exiftool -Comment -Copyright -XMP-dc:Rights your-image.jpg
+```
+
+### PNG — ExifTool
+
+PNG uses a different metadata structure but ExifTool handles it:
+
+```bash
+exiftool \
+  -PNG:Comment="DAON:sha256:YOUR_HASH_HERE" \
+  -XMP-dc:Rights="https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  -XMP-xmpRights:WebStatement="https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  your-image.png
+```
+
+Note: PNG's native `tEXt` chunk doesn't support all EXIF fields. The XMP fields above are the most portable.
+
+### Adobe Lightroom / Lightroom Classic
+
+1. Select your image(s)
+2. **Metadata panel → IPTC Content section**
+3. In **Copyright**: `© YOUR_NAME. DAON verified.`
+4. In **Rights Usage Terms**: `https://app.daon.network/verify/sha256:YOUR_HASH_HERE`
+5. **File → Export** → check "Write Keywords as Lightroom Hierarchy" and ensure metadata is included in export settings
+
+To embed permanently in the source file:
+- **Metadata → Save Metadata to File** (Ctrl/Cmd+S)
+
+### Adobe Photoshop
+
+1. **File → File Info** (Alt+Shift+Ctrl+I / Option+Shift+Cmd+I)
+2. **Basic tab**:
+   - **Description**: `DAON:sha256:YOUR_HASH_HERE`
+   - **Copyright Status**: Copyrighted
+   - **Copyright Notice**: `© YOUR_NAME. Verify: https://app.daon.network/verify/sha256:YOUR_HASH_HERE`
+   - **Copyright Info URL**: `https://app.daon.network/verify/sha256:YOUR_HASH_HERE`
+3. Click OK and save
+
+### Capture One
+
+1. Select image(s) in the browser
+2. **Metadata tool tab** → **IPTC** section
+3. **Copyright**: `© YOUR_NAME. DAON:sha256:YOUR_HASH_HERE`
+4. **Rights Usage Terms**: `https://app.daon.network/verify/sha256:YOUR_HASH_HERE`
+5. Export with **Include Metadata** checked
+
+### GIMP
+
+1. **File → Export As** → your filename
+2. In the export dialog, click **Advanced Options**
+3. Check **Save EXIF data** and **Save XMP data**
+4. Before exporting, set metadata via **Image → Image Properties** or install the Metadata plugin
+
+For full control, export with GIMP then apply ExifTool afterward — it's more reliable.
+
+### Web embedding pattern for images
+
+```html
+<head>
+  <meta name="daon-hash"
+        content="sha256:YOUR_HASH_HERE"
+        id="daon-img-1">
+  <meta name="daon-content-type"
+        content="application/octet-stream"
+        data-for="daon-img-1">
+</head>
+<body>
+  <figure>
+    <img src="your-image.jpg"
+         data-daon-ref="daon-img-1"
+         alt="Description of your image">
+    <figcaption>
+      © YOUR_NAME —
+      <a href="https://app.daon.network/verify/sha256:YOUR_HASH_HERE">Verify ownership</a>
+    </figcaption>
+  </figure>
+</body>
+```
+
+---
+
+## Video
+
+### MP4 / MOV (QuickTime)
+
+```bash
+exiftool \
+  -Title="YOUR_TITLE" \
+  -Artist="YOUR_NAME" \
+  -Copyright="© YOUR_NAME. DAON:sha256:YOUR_HASH_HERE" \
+  -Comment="DAON:sha256:YOUR_HASH_HERE. Verify: https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  -XMP-dc:Rights="https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  -XMP-xmpRights:WebStatement="https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  -XMP-xmpRights:Marked=True \
+  your-video.mp4
+```
+
+### MKV (Matroska)
+
+MKV uses its own tagging format. Use [mkvpropedit](https://mkvtoolnix.download/) (part of MKVToolNix):
+
+```bash
+mkvpropedit your-video.mkv \
+  --edit info \
+  --set "title=YOUR_TITLE" \
+  --add-track-statistics-tags
+
+# For custom tags:
+mkvpropedit your-video.mkv \
+  --tags "global:tags.xml"
+```
+
+Where `tags.xml` contains:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Tags>
+  <Tag>
+    <Targets/>
+    <Simple>
+      <Name>COPYRIGHT</Name>
+      <String>© YOUR_NAME. DAON:sha256:YOUR_HASH_HERE</String>
+    </Simple>
+    <Simple>
+      <Name>DAON_HASH</Name>
+      <String>sha256:YOUR_HASH_HERE</String>
+    </Simple>
+    <Simple>
+      <Name>DAON_VERIFY</Name>
+      <String>https://app.daon.network/verify/sha256:YOUR_HASH_HERE</String>
+    </Simple>
+  </Tag>
+</Tags>
+```
+
+### WebM
+
+```bash
+exiftool \
+  -Copyright="© YOUR_NAME. DAON:sha256:YOUR_HASH_HERE" \
+  -Comment="Verify: https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  your-video.webm
+```
+
+### Video description text (YouTube, Vimeo, etc.)
+
+All major video platforms strip file metadata. In your video description:
+
+```
+This video is registered on the DAON blockchain.
+
+Ownership verification: https://app.daon.network/verify/sha256:YOUR_HASH_HERE
+Registration hash: sha256:YOUR_HASH_HERE
+
+AI training on this content is prohibited under the Liberation License.
+Contact for licensing: YOUR_EMAIL
+```
+
+---
+
+## Audio
+
+### MP3 — ID3v2 tags
+
+MP3 uses ID3v2 tags. ExifTool writes them:
+
+```bash
+exiftool \
+  -Title="YOUR_TITLE" \
+  -Artist="YOUR_NAME" \
+  -Copyright="© YOUR_NAME. DAON:sha256:YOUR_HASH_HERE" \
+  -Comment="DAON:sha256:YOUR_HASH_HERE. Verify: https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  -TCOP="© YOUR_NAME. DAON verified." \
+  your-audio.mp3
+```
+
+Or with `id3v2` directly:
+```bash
+id3v2 \
+  --artist "YOUR_NAME" \
+  --song "YOUR_TITLE" \
+  --comment "DAON:sha256:YOUR_HASH_HERE | https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  your-audio.mp3
+```
+
+### FLAC — Vorbis comments
+
+FLAC uses plain-text Vorbis comments. Use `metaflac`:
+
+```bash
+metaflac \
+  --set-tag="TITLE=YOUR_TITLE" \
+  --set-tag="ARTIST=YOUR_NAME" \
+  --set-tag="COPYRIGHT=© YOUR_NAME. DAON:sha256:YOUR_HASH_HERE" \
+  --set-tag="DAON_HASH=sha256:YOUR_HASH_HERE" \
+  --set-tag="DAON_VERIFY=https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  your-audio.flac
+```
+
+### OGG Vorbis
+
+```bash
+vorbiscomment -w your-audio.ogg << 'EOF'
+TITLE=YOUR_TITLE
+ARTIST=YOUR_NAME
+COPYRIGHT=© YOUR_NAME. DAON:sha256:YOUR_HASH_HERE
+DAON_HASH=sha256:YOUR_HASH_HERE
+DAON_VERIFY=https://app.daon.network/verify/sha256:YOUR_HASH_HERE
+EOF
+```
+
+### AAC / M4A / Apple Music
+
+```bash
+exiftool \
+  -Title="YOUR_TITLE" \
+  -Artist="YOUR_NAME" \
+  -Copyright="© YOUR_NAME. DAON:sha256:YOUR_HASH_HERE" \
+  -Comment="Verify: https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  your-audio.m4a
+```
+
+### WAV
+
+WAV supports INFO chunks:
+
+```bash
+exiftool \
+  -RIFF:Artist="YOUR_NAME" \
+  -RIFF:Copyright="© YOUR_NAME. DAON:sha256:YOUR_HASH_HERE" \
+  -RIFF:Comment="DAON:sha256:YOUR_HASH_HERE | https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  your-audio.wav
+```
+
+### Audacity
+
+Audacity doesn't have full metadata editing built in. Export your file, then apply ExifTool afterward. For MP3, use the ID3 tag instructions above post-export.
+
+---
+
+## PDF Documents
+
+### ExifTool (most reliable)
+
+```bash
+exiftool \
+  -Title="YOUR_TITLE" \
+  -Author="YOUR_NAME" \
+  -Subject="DAON:sha256:YOUR_HASH_HERE" \
+  -Keywords="daon-verified, sha256:YOUR_HASH_HERE" \
+  -Rights="© YOUR_NAME. AI training prohibited. Verify: https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  -XMP-dc:Rights="https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  -XMP-xmpRights:WebStatement="https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
+  -XMP-xmpRights:Marked=True \
+  your-document.pdf
+```
+
+### Document body
+
+Add a footer or final page visible in the document itself:
+
+```
+────────────────────────────────────────
+This document is registered on the DAON blockchain.
+Owner: YOUR_NAME
+Registration hash: sha256:YOUR_HASH_HERE
+Verification: https://app.daon.network/verify/sha256:YOUR_HASH_HERE
+AI training on this content is prohibited.
+────────────────────────────────────────
+```
+
+---
+
+## Word / DOCX
+
+### Via the Word UI (Windows / Mac)
+
+1. **File → Info → Properties** (right panel) → **Advanced Properties**
+2. **Summary tab**:
+   - **Author**: Your name
+   - **Comments**: `DAON:sha256:YOUR_HASH_HERE. Verify: https://app.daon.network/verify/sha256:YOUR_HASH_HERE`
+3. **Custom tab** → **Add**:
+   - Name: `DAON-Hash`, Value: `sha256:YOUR_HASH_HERE`
+   - Name: `DAON-Verify`, Value: `https://app.daon.network/verify/sha256:YOUR_HASH_HERE`
+4. Click OK and save
+
+### Via python-docx (command line / scripted)
+
+```python
+from docx import Document
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+
+doc = Document("your-document.docx")
+props = doc.core_properties
+props.author = "YOUR_NAME"
+props.comments = f"DAON:sha256:YOUR_HASH_HERE. Verify: https://app.daon.network/verify/sha256:YOUR_HASH_HERE"
+props.subject = "DAON:sha256:YOUR_HASH_HERE"
+props.keywords = "daon-verified"
+doc.save("your-document.docx")
+```
+
+### In the document body
+
+Add a footer via **Insert → Footer**:
+
+```
+DAON Verification: sha256:YOUR_HASH_HERE | https://app.daon.network/verify/sha256:YOUR_HASH_HERE
+```
+
+---
+
+## LibreOffice / ODT
+
+### Via the LibreOffice UI
+
+1. **File → Properties**
+2. **Description tab**:
+   - **Subject**: `DAON:sha256:YOUR_HASH_HERE`
+   - **Comments**: `Verify: https://app.daon.network/verify/sha256:YOUR_HASH_HERE`
+3. **Custom Properties tab** → **Add Property**:
+   - `DAON-Hash`: `sha256:YOUR_HASH_HERE`
+   - `DAON-Verify`: `https://app.daon.network/verify/sha256:YOUR_HASH_HERE`
+4. Click OK and save
+
+ODT files are ZIP archives containing XML. The custom properties are stored in `meta.xml` inside the file and survive most format conversions.
+
+---
+
+## EPUB
+
+EPUB uses OPF XML metadata. Open your `.epub` file (it's a ZIP), find `content.opf` or `package.opf`, and add to the `<metadata>` section:
+
+```xml
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/"
+          xmlns:opf="http://www.idpf.org/2007/opf">
+  <dc:creator>YOUR_NAME</dc:creator>
+  <dc:rights>© YOUR_NAME. DAON:sha256:YOUR_HASH_HERE. AI training prohibited.</dc:rights>
+  <dc:description>DAON verification: https://app.daon.network/verify/sha256:YOUR_HASH_HERE</dc:description>
+  <meta name="daon-hash" content="sha256:YOUR_HASH_HERE"/>
+  <meta name="daon-verify" content="https://app.daon.network/verify/sha256:YOUR_HASH_HERE"/>
+</metadata>
+```
+
+To edit: `unzip book.epub -d book_dir`, edit `content.opf`, then `cd book_dir && zip -X ../book_updated.epub mimetype && zip -rg ../book_updated.epub . -x mimetype`.
+
+Many EPUB editors (Sigil, Calibre) also expose metadata fields directly:
+
+**Calibre:**
+1. Right-click the book → **Edit metadata**
+2. **Comments** field: paste the full verification block
+3. **Custom columns** if you've set them up: add `daon-hash` and `daon-verify`
+
+---
+
+## SVG
+
+SVG is XML — you can embed metadata directly:
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:cc="http://creativecommons.org/ns#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     width="..." height="...">
+
+  <metadata>
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:creator><dc:Agent><dc:title>YOUR_NAME</dc:title></dc:Agent></dc:creator>
+        <dc:rights>© YOUR_NAME. DAON:sha256:YOUR_HASH_HERE</dc:rights>
+        <cc:license rdf:resource="https://app.daon.network/verify/sha256:YOUR_HASH_HERE"/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+
+  <!-- add a visible comment too -->
+  <!-- DAON:sha256:YOUR_HASH_HERE | https://app.daon.network/verify/sha256:YOUR_HASH_HERE -->
+
+  <!-- rest of your SVG -->
+</svg>
+```
+
+Inkscape exposes this via **File → Document Properties → Metadata**.
+
+---
+
+## Source Code
+
+Add a DAON header comment to source files. The convention is consistent across languages:
+
+**JavaScript / TypeScript / Go / Rust / C / C++:**
+```js
+/**
+ * DAON: sha256:YOUR_HASH_HERE
+ * Verify: https://app.daon.network/verify/sha256:YOUR_HASH_HERE
+ * © YOUR_NAME. All rights reserved. AI training prohibited.
+ */
+```
+
+**Python / Ruby / Shell:**
+```python
+# DAON: sha256:YOUR_HASH_HERE
+# Verify: https://app.daon.network/verify/sha256:YOUR_HASH_HERE
+# © YOUR_NAME. All rights reserved. AI training prohibited.
+```
+
+**HTML / XML:**
+```html
+<!-- DAON: sha256:YOUR_HASH_HERE | https://app.daon.network/verify/sha256:YOUR_HASH_HERE -->
+```
+
+**For repositories:** add a `DAON.md` or append to `LICENSE`:
+```
+DAON Registration
+-----------------
+Hash:   sha256:YOUR_HASH_HERE
+Verify: https://app.daon.network/verify/sha256:YOUR_HASH_HERE
+Owner:  YOUR_NAME
+```
+
+---
+
+## Plain Text and Markdown
+
+Use the first or last line convention:
+
+**First line:**
+```
+[DAON: sha256:YOUR_HASH_HERE | https://app.daon.network/verify/sha256:YOUR_HASH_HERE]
+```
+
+**Last line:**
+```
+---
+DAON Verification: sha256:YOUR_HASH_HERE
+https://app.daon.network/verify/sha256:YOUR_HASH_HERE
+```
+
+This works for `.txt`, `.md`, fanfic plain-text archives, README files, and any format that can't carry metadata.
+
+---
+
+## XMP Sidecar Files
+
+When you can't embed metadata in the file itself — for example, formats that don't support it, or files you don't want to modify — use an XMP sidecar. Most professional tools and DAMs (Digital Asset Managers) recognize them.
+
+Create `your-file.xmp` alongside `your-file.whatever`:
+
+```xml
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about=""
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:xmpRights="http://ns.adobe.com/xap/1.0/rights/">
+      <dc:creator>
+        <rdf:Seq><rdf:li>YOUR_NAME</rdf:li></rdf:Seq>
+      </dc:creator>
+      <dc:rights>
+        <rdf:Alt><rdf:li xml:lang="x-default">© YOUR_NAME. DAON:sha256:YOUR_HASH_HERE</rdf:li></rdf:Alt>
+      </dc:rights>
+      <xmpRights:WebStatement>https://app.daon.network/verify/sha256:YOUR_HASH_HERE</xmpRights:WebStatement>
+      <xmpRights:Marked>True</xmpRights:Marked>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>
+```
+
+The sidecar must have the same base filename as the asset and live in the same directory.
+
+---
+
+## AO3 / Wattpad / Fanfiction.Net
+
+### AO3 (Archive of Our Own)
+
+AO3 doesn't allow `<head>` access. Use the visible link form in **Author's Notes** (beginning or end):
+
+```html
+<p>This work is registered on the DAON blockchain.
+<a href="https://app.daon.network/verify/sha256:YOUR_HASH_HERE">[Verify ownership]</a>
+— AI training prohibited under the Liberation License.</p>
+```
+
+**Where to add it:**
+1. Go to your work → Edit
+2. Scroll to "Preface" or "End Notes"
+3. Paste the snippet, replace the hash
+4. Save
+
+### Wattpad / Fanfiction.Net / Royal Road
+
+Most platforms allow plain text or limited HTML in story descriptions and author notes:
+
+```
+This work is registered on the DAON blockchain.
+Proof of ownership: https://app.daon.network/verify/sha256:YOUR_HASH_HERE
+AI training prohibited.
+```
+
+---
+
+## WordPress / Self-Hosted Blog
 
 **In `<head>`** (via theme `functions.php` or a plugin like "Insert Headers and Footers"):
 
@@ -82,136 +648,109 @@ Add both the machine-readable tags and a visible badge.
 
 ---
 
-### AO3 (Archive of Our Own)
+## Social Media
 
-AO3 doesn't allow `<head>` access, so use the visible link form in **Author's Notes**:
+**⚠️ All major social platforms strip file metadata on upload.** The only reliable embed is in visible text.
 
-```html
-<p>This work is registered on the DAON blockchain.
-<a href="https://app.daon.network/verify/sha256:YOUR_HASH_HERE" rel="nofollow">
-  [Verify ownership]
-</a></p>
+**In bio / profile:**
+```
+Creator | DAON-verified | app.daon.network
 ```
 
-Replace `YOUR_HASH_HERE` with your 64-character hex hash (shown on your registration confirmation screen).
+**In posts / captions:**
+```
+DAON registered. Verify: https://app.daon.network/verify/sha256:YOUR_HASH_HERE
+AI training prohibited under the Liberation License.
+```
 
-**Where to add it:**
-1. Go to your work → Edit
-2. Scroll to "Preface" or "End Notes"
-3. Paste the snippet, replace the hash
-4. Save
+**On Tumblr:** You can add the full verification URL to the post body, author notes, or a pinned post.
+
+**On Bluesky:** Paste the verification URL into your post text. It will linkify.
 
 ---
 
-### Images (JPEG / PNG / TIFF)
+## Declaring Boundaries for AI Crawlers
 
-Embed directly in the file's EXIF/IPTC metadata using [ExifTool](https://exiftool.org/):
+Beyond embedding tokens in individual files, you can declare a site-wide boundary for AI crawlers using `robots.txt` and HTTP headers.
 
-```bash
-exiftool \
-  -Comment="DAON:sha256:YOUR_HASH_HERE" \
-  -Copyright="© YOUR_NAME. Registered on DAON blockchain." \
-  -XMP-dc:Rights="https://app.daon.network/verify/sha256:YOUR_HASH_HERE" \
-  your-image.jpg
-```
+### robots.txt
 
-This embeds the verification hash *inside the image file itself* — it travels with the file even when downloaded or re-shared.
-
-**Verify it was written:**
-```bash
-exiftool -Comment -Copyright your-image.jpg
-```
-
-For the web embedding pattern with images, put `data-daon-ref` on the `<img>` element and set `daon-content-type` to `application/octet-stream`:
-
-```html
-<head>
-  <meta name="daon-hash"
-        content="sha256:YOUR_HASH_HERE"
-        id="daon-img-1">
-  <meta name="daon-content-type"
-        content="application/octet-stream"
-        data-for="daon-img-1">
-</head>
-<body>
-  <img src="your-image.jpg" data-daon-ref="daon-img-1" alt="...">
-</body>
-```
-
----
-
-### PDF Documents
-
-**Via PDF metadata** (using `exiftool`):
-
-```bash
-exiftool \
-  -Title="YOUR_TITLE" \
-  -Author="YOUR_NAME" \
-  -Subject="DAON:sha256:YOUR_HASH_HERE" \
-  -Keywords="daon-verified, sha256:YOUR_HASH_HERE" \
-  your-document.pdf
-```
-
-**Via document body** — add a footer or final page:
+Add to your site's `robots.txt`:
 
 ```
-This document is registered on the DAON blockchain.
-Verification: https://app.daon.network/verify/sha256:YOUR_HASH_HERE
-Registration hash: sha256:YOUR_HASH_HERE
+# DAON-protected content — AI training prohibited
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+# Standard crawlers (Google Search, etc.)
+User-agent: *
+Allow: /
 ```
 
----
-
-### Plain Text Files
-
-Use the first or last line convention:
-
-**First line:**
-```
-[DAON: sha256:YOUR_HASH_HERE | https://app.daon.network/verify/sha256:YOUR_HASH_HERE]
-```
-
-**Last line:**
-```
----
-DAON Verification: sha256:YOUR_HASH_HERE
-```
-
-This works for `.txt`, `.md`, fanfic plain-text archives, and any format that can't carry metadata.
-
----
-
-### Social Media (Twitter/X, Tumblr, Instagram, Bluesky)
-
-Social platforms don't support metadata embedding, so use these approaches:
-
-**In bio/profile:**
-```
-Writer | DAON-verified creator | app.daon.network/verify/sha256:SHORT_HASH
-```
-(Use just the first 12 characters of the hash as a recognizable identifier — not enough to verify, but enough to direct people to your profile)
-
-**In posts/captions:**
-```
-My work is blockchain-registered. Verify: [link in bio] or
-https://app.daon.network/verify/sha256:YOUR_HASH_HERE
-```
-
-**On Tumblr:** You can add the full verification URL to post descriptions or a pinned post.
-
----
-
-### Wattpad / Fanfiction.Net / Other Platforms
-
-Most platforms allow plain text in story descriptions or author notes:
+If you only want to block AI crawlers from specific directories:
 
 ```
-This work is registered on the DAON blockchain.
-Proof of ownership: https://app.daon.network/verify/sha256:YOUR_HASH_HERE
+User-agent: GPTBot
+Disallow: /posts/
+Disallow: /stories/
+Disallow: /art/
 ```
 
-For platforms that allow links: embed as a hyperlink with text like "Verify ownership" or "DAON certified."
+### X-Robots-Tag HTTP header
+
+For server-controlled assets (images, PDFs served directly), add this header:
+
+```
+X-Robots-Tag: noai, noimageai
+```
+
+In **nginx**:
+```nginx
+location ~* \.(jpg|jpeg|png|gif|pdf|mp3|mp4)$ {
+    add_header X-Robots-Tag "noai, noimageai";
+}
+```
+
+In **Apache** (`.htaccess`):
+```apache
+<FilesMatch "\.(jpg|jpeg|png|gif|pdf|mp3|mp4)$">
+    Header set X-Robots-Tag "noai, noimageai"
+</FilesMatch>
+```
+
+### What these declarations mean
+
+Like `robots.txt`, these are declared boundaries — not hard technical walls. A crawler that wants to ignore them can. But:
+
+- Ignoring a declared, machine-readable boundary is a deliberate choice
+- Your DAON registration timestamps your ownership claim *before* any scraping event
+- Together, the meta tags, `robots.txt` entries, and DAON record make the boundary as legible and legally defensible as possible
+
+The goal isn't to make scraping impossible. It's to make ignoring your boundaries an unambiguous, documented act.
 
 ---
 


### PR DESCRIPTION
## Summary

Complete rewrite of `docs/creators/embedding-tokens.md`. Now covers:

**File formats added:**
- Images: JPEG/TIFF/PNG (ExifTool), Lightroom, Photoshop, Capture One, GIMP, SVG
- Video: MP4/MOV, MKV (mkvpropedit + XML tags), WebM
- Audio: MP3 ID3v2, FLAC (metaflac), OGG Vorbis, AAC/M4A, WAV INFO chunks
- Documents: DOCX (UI + python-docx), LibreOffice/ODT, EPUB (OPF metadata, Calibre/Sigil)
- Source code: JS/TS/Python/Ruby/Go comment header convention
- XMP sidecar files for formats that can't be modified directly

**Crawler boundaries added:**
- `robots.txt` directives for all major AI crawlers (GPTBot, CCBot, anthropic-ai, Claude-Web, Google-Extended, etc.)
- `X-Robots-Tag` header examples for nginx and Apache
- Explanation of what declared boundaries mean legally vs technically

**Key additions:**
- Metadata stripping warning (social platforms strip EXIF — use visible text instead)
- The robots.txt analogy explaining what DAON protection is and isn't
- Table of contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)