### PR TITLE
fix(api): associate registrations with authenticated user + correct DAON name + public roadmap

### DIFF
--- a/api-server/src/auth/auth.ts
+++ b/api-server/src/auth/auth.ts
@@ -11,7 +11,7 @@ const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:3000';
 /**
  * Email transporter configuration
  */
-const emailTransporter = nodemailer.createTransporter({
+const emailTransporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST || 'smtp.gmail.com',
   port: parseInt(process.env.SMTP_PORT || '587'),
   secure: false, // true for 465, false for other ports

--- a/api-server/src/server.ts
+++ b/api-server/src/server.ts
@@ -20,6 +20,7 @@ import blockchainClient from './blockchain.js';
 import { DatabaseClient, db } from './database/client.js';
 import createAuthRoutes from './auth/auth-routes.js';
 import { requireAdminAuth, logAdminAction } from './auth/admin-middleware.js';
+import { verifyToken } from './auth/auth.js';
 import healthRoutes from './routes/health.js';
 import { BrokerService } from './broker/broker-service.js';
 import { createBrokerAuthMiddleware } from './broker/broker-auth-middleware.js';
@@ -184,6 +185,16 @@ app.use((req, res, next) => {
 });
 
 // Validation middleware helper
+// Optional auth: attaches req.userId if a valid Bearer token is present, otherwise continues anonymously
+const optionalAuth = (req: any, _res: any, next: any) => {
+  const authHeader = req.headers['authorization'];
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const decoded = verifyToken(authHeader.substring(7));
+    if (decoded) req.userId = decoded.userId;
+  }
+  next();
+};
+
 const handleValidationErrors = (req, res, next) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
@@ -299,7 +310,7 @@ app.get('/api/v1', (req, res) => {
 });
 
 // Content protection endpoint
-app.post('/api/v1/protect', [
+app.post("/api/v1/protect", [optionalAuth,
   body('content')
     .notEmpty()
     .withMessage('Content is required')
@@ -452,6 +463,7 @@ app.post('/api/v1/protect', [
     // Persist to database so all instances and restarts can verify
     try {
       await db.content.create({
+        user_id: req.userId || null,
         content_hash: contentHash,
         title: metadata.title || 'Untitled Work',
         description: metadata.description,

--- a/daon-frontend/app/layout 2.tsx
+++ b/daon-frontend/app/layout 2.tsx
@@ -7,7 +7,7 @@ import ErrorBoundary from "../components/ErrorBoundary";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "DAON - Decentralized Author Ownership Network",
+  title: "DAON - Digital Asset Ownership Network",
   description: "Privacy-first authentication for content creators",
 };
 

--- a/daon-frontend/app/layout.tsx
+++ b/daon-frontend/app/layout.tsx
@@ -7,7 +7,7 @@ import ErrorBoundary from "../components/ErrorBoundary";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "DAON - Decentralized Author Ownership Network",
+  title: "DAON - Digital Asset Ownership Network",
   description: "Privacy-first authentication for content creators",
 };
 

--- a/verification-service/app/verify/[hash]/page.tsx
+++ b/verification-service/app/verify/[hash]/page.tsx
@@ -333,7 +333,7 @@ export default function VerifyPage() {
 
         {/* Footer */}
         <div className="text-center mt-8 text-sm text-gray-500">
-          <p>Powered by DAON - Decentralized Author Ownership Network</p>
+          <p>Powered by DAON - Digital Asset Ownership Network</p>
           <p className="mt-1">
             <a href="/" className="text-blue-600 hover:text-blue-700 underline">
               Learn More


### PR DESCRIPTION
## Summary

**Bug fix — user_id not saved on registrations:**
- `/protect` endpoint accepted Bearer tokens but never used them — `user_id` was always `null`
- Added `optionalAuth` middleware that extracts `userId` from a valid JWT if present
- Anonymous registrations via SDK still work (`user_id` remains `null`)

**Bug fix — wrong full name:**
- "Decentralized Author Ownership Network" → "Digital Asset Ownership Network" in page title and verification service footer

**Docs:**
- Public roadmap at `daon.network/roadmap/` (added to nav)
- Comprehensive embedding guide covering all file formats, image editors, robots.txt AI crawler directives

🤖 Generated with [Claude Code](https://claude.com/claude-code)