### PR TITLE
fix(deploy): reliably restart containers + fix user_id on registrations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -238,8 +238,13 @@ jobs:
             # Build blockchain image locally
             docker build -t daon-blockchain:latest ./daon-core
 
-            # Deploy full stack — force-recreate ensures new images are actually used
-            docker compose up -d --remove-orphans --force-recreate
+            # Stop and remove app containers so new images are guaranteed to run
+            # (--force-recreate is unreliable when container_name is set)
+            docker compose stop daon-api daon-frontend daon-blockchain 2>/dev/null || true
+            docker compose rm -f daon-api daon-frontend daon-blockchain 2>/dev/null || true
+
+            # Deploy full stack
+            docker compose up -d --remove-orphans
             
             # Run database migrations (all are idempotent via IF NOT EXISTS)
             echo "⏳ Waiting for postgres to be ready..."


### PR DESCRIPTION
## Summary

**fix(deploy): stop+rm containers before up — force-recreate unreliable with container_name**
- `--force-recreate` doesn't reliably restart containers when `container_name` is explicitly set in compose
- Explicitly stops and removes `daon-api`, `daon-frontend`, `daon-blockchain` before `docker compose up`
- Guarantees newly built images are actually used

**fix(api): user_id now saved on content registrations**
- `/protect` was ignoring Bearer tokens — `user_id` always null
- Added `optionalAuth` middleware; anonymous SDK registrations still work

**fix(auth): createTransporter → createTransport (nodemailer v8)**

**fix(frontend): DAON full name corrected**

**docs: public roadmap + comprehensive embedding guide**

🤖 Generated with [Claude Code](https://claude.com/claude-code)