### PR TITLE
fix(infra): persistent volumes, DB backups, chain reindex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,20 @@
 # Large compiled binaries
 daon-core/daon-cored
 daon-core/build/
+
+# Dependencies & build artifacts
 **/node_modules/
+api-server/dist/
+sdks/python/**/__pycache__/
+sdks/ruby/.bundle/
+sdks/ruby/vendor/
+
+# OS & editor
 **/.DS_Store
 *.log
+
+# Environment & secrets
 .env
+
+# Test artifacts
+load-results-*.json

--- a/api-server/src/database/init-production.sh
+++ b/api-server/src/database/init-production.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Auto-initialize DAON database schema when Postgres creates a fresh volume.
+# Postgres runs scripts in /docker-entrypoint-initdb.d/ alphabetically on first init only.
+set -e
+
+echo "=== DAON: Initializing database schema ==="
+
+# Load base schema
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" \
+  -f /docker-entrypoint-initdb.d/schema.sql
+
+# Run migrations in order
+for f in /docker-entrypoint-initdb.d/migrations/*.sql; do
+  if [ -f "$f" ]; then
+    echo "=== Running migration: $(basename "$f") ==="
+    psql -v ON_ERROR_STOP=0 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" -f "$f"
+  fi
+done
+
+echo "=== DAON: Database schema initialized ==="

--- a/api-server/src/database/migrations/005_add_ai_licensing.sql
+++ b/api-server/src/database/migrations/005_add_ai_licensing.sql
@@ -7,17 +7,23 @@ ALTER TABLE protected_content
   ADD COLUMN IF NOT EXISTS licensing_email VARCHAR(255),
   ADD COLUMN IF NOT EXISTS licensing_uri TEXT;
 
-ALTER TABLE protected_content
-  ADD CONSTRAINT IF NOT EXISTS valid_ai_training_policy
-    CHECK (ai_training_policy IN ('prohibited', 'contact_required', 'open'));
+DO $$ BEGIN
+  ALTER TABLE protected_content
+    ADD CONSTRAINT valid_ai_training_policy
+      CHECK (ai_training_policy IN ('prohibited', 'contact_required', 'open'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 
 -- Enforce: contact_required must have at least one contact method
-ALTER TABLE protected_content
-  ADD CONSTRAINT IF NOT EXISTS licensing_contact_when_required
-    CHECK (
-      ai_training_policy != 'contact_required'
-      OR (licensing_email IS NOT NULL OR licensing_uri IS NOT NULL)
-    );
+DO $$ BEGIN
+  ALTER TABLE protected_content
+    ADD CONSTRAINT licensing_contact_when_required
+      CHECK (
+        ai_training_policy != 'contact_required'
+        OR (licensing_email IS NOT NULL OR licensing_uri IS NOT NULL)
+      );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 
 CREATE INDEX IF NOT EXISTS idx_content_ai_policy ON protected_content(ai_training_policy);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - "127.0.0.1:26656:26656"  # P2P
       - "127.0.0.1:1317:1317"    # REST API
     volumes:
-      - daon-blockchain-data:/daon/.daon
+      - /mnt/HC_Volume_103956354/blockchain:/daon/.daon
     environment:
       CHAIN_ID: daon-mainnet-1
       MONIKER: daon-validator-1
@@ -99,7 +99,10 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
-      - daon-postgres-data:/var/lib/postgresql/data
+      - /mnt/HC_Volume_103956354/postgres:/var/lib/postgresql/data
+      - ./api-server/src/database/init-production.sh:/docker-entrypoint-initdb.d/01-init.sh:ro
+      - ./api-server/src/database/schema.sql:/docker-entrypoint-initdb.d/schema.sql:ro
+      - ./api-server/src/database/migrations:/docker-entrypoint-initdb.d/migrations:ro
     ports:
       - "127.0.0.1:5432:5432"
     healthcheck:
@@ -275,6 +278,4 @@ networks:
     name: daon-network
 
 volumes:
-  daon-blockchain-data:
-  daon-postgres-data:
   daon-api-logs:

--- a/documentation/project/DAON_ROADMAP.md
+++ b/documentation/project/DAON_ROADMAP.md
@@ -1,5 +1,5 @@
 # DAON Product Roadmap
-**Last updated:** April 2026
+**Last updated:** May 2026
 **Status:** Live on mainnet. Accepting users.
 
 ---
@@ -78,7 +78,8 @@ The broker system lets third-party platforms register content on behalf of their
 | Transfer blockchain integration | Critical | Transfers write to DB only; not on-chain |
 | Broker onboarding documentation | High | Required before first partner |
 | Broker Node.js SDK | High | Reference implementation for integrators |
-| AI licensing fields | High | `ai_training_policy`, `licensing_email`, `licensing_uri` absent from schema |
+| AI licensing fields | ~~High~~ | ~~`ai_training_policy`, `licensing_email`, `licensing_uri` absent from schema~~ **Shipped** (PR #71) |
+| 2FA recovery via backup codes | High | Allow users to disable/reset 2FA using a backup code when they've lost their authenticator. Currently backup codes can authenticate but not reset 2FA — users who lose their authenticator AND don't have a trusted device are permanently locked out. |
 | License record API (audit trail) | High | Brokers record that licensing occurred |
 | Redis for rate limiting | High | General API rate limits use in-memory store (resets on restart) |
 | Identity linking (federated → DAON account) | Medium | User claims their platform content |

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# DAON Database Backup Script
+# Runs pg_dump inside the postgres container and stores on the backup volume.
+# Keeps the last 30 daily backups; older ones are pruned automatically.
+
+set -euo pipefail
+
+BACKUP_DIR="/mnt/HC_Volume_103960188/backups/postgres"
+CONTAINER="daon-postgres"
+DB_USER="daon_api"
+DB_NAME="daon_production"
+RETENTION_DAYS=30
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+BACKUP_FILE="${BACKUP_DIR}/daon_${TIMESTAMP}.sql.gz"
+
+mkdir -p "$BACKUP_DIR"
+
+echo "[$(date)] Starting database backup..."
+
+# Dump and compress
+docker exec "$CONTAINER" pg_dump -U "$DB_USER" -d "$DB_NAME" --no-owner --no-acl \
+  | gzip > "$BACKUP_FILE"
+
+SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
+echo "[$(date)] Backup complete: $BACKUP_FILE ($SIZE)"
+
+# Prune old backups
+PRUNED=$(find "$BACKUP_DIR" -name "daon_*.sql.gz" -mtime +${RETENTION_DAYS} -print -delete | wc -l)
+if [ "$PRUNED" -gt 0 ]; then
+  echo "[$(date)] Pruned $PRUNED backup(s) older than ${RETENTION_DAYS} days"
+fi
+
+# Verify backup is non-empty
+MIN_SIZE=1024
+ACTUAL_SIZE=$(stat -c%s "$BACKUP_FILE" 2>/dev/null || stat -f%z "$BACKUP_FILE" 2>/dev/null)
+if [ "$ACTUAL_SIZE" -lt "$MIN_SIZE" ]; then
+  echo "[$(date)] WARNING: Backup file is suspiciously small (${ACTUAL_SIZE} bytes)" >&2
+  exit 1
+fi
+
+echo "[$(date)] Backup verified OK"

--- a/scripts/reindex-from-chain.py
+++ b/scripts/reindex-from-chain.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""
+DAON Reindex Script
+Scans all blockchain transactions and rebuilds the protected_content table.
+Run on the server: python3 /opt/daon/scripts/reindex-from-chain.py
+"""
+
+import json
+import base64
+import urllib.request
+import subprocess
+import sys
+import re
+from datetime import datetime, timezone
+
+RPC = "http://localhost:26657"
+PER_PAGE = 100
+CONTAINER = "daon-postgres"
+DB_USER = "daon_api"
+DB_NAME = "daon_production"
+MSG_TYPE_URL = "/daoncore.contentregistry.v1.MsgRegisterContent"
+
+
+def fetch_json(url):
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+def decode_varint(data, pos):
+    """Decode a protobuf varint starting at pos. Returns (value, new_pos)."""
+    result = 0
+    shift = 0
+    while pos < len(data):
+        b = data[pos]
+        result |= (b & 0x7F) << shift
+        pos += 1
+        if (b & 0x80) == 0:
+            break
+        shift += 7
+    return result, pos
+
+
+def decode_length_delimited(data, pos):
+    """Decode a length-delimited field. Returns (bytes, new_pos)."""
+    length, pos = decode_varint(data, pos)
+    return data[pos:pos + length], pos + length
+
+
+def parse_protobuf_strings(data):
+    """Parse a simple protobuf message with only string fields.
+    Returns dict of field_number -> bytes."""
+    fields = {}
+    pos = 0
+    while pos < len(data):
+        try:
+            tag, pos = decode_varint(data, pos)
+            field_number = tag >> 3
+            wire_type = tag & 0x07
+            if wire_type == 2:  # length-delimited
+                value, pos = decode_length_delimited(data, pos)
+                fields[field_number] = value
+            elif wire_type == 0:  # varint
+                _, pos = decode_varint(data, pos)
+            elif wire_type == 1:  # 64-bit
+                pos += 8
+            elif wire_type == 5:  # 32-bit
+                pos += 4
+            else:
+                break
+        except (IndexError, ValueError):
+            break
+    return fields
+
+
+def parse_tx(tx_base64):
+    """Parse a cosmos transaction and extract MsgRegisterContent + memo."""
+    raw = base64.b64decode(tx_base64)
+
+    # TxRaw: field 1 = bodyBytes, field 2 = authInfoBytes, field 3 = signatures
+    tx_raw_fields = parse_protobuf_strings(raw)
+    body_bytes = tx_raw_fields.get(1, b"")
+    if not body_bytes:
+        return None
+
+    # TxBody: field 1 = messages (repeated Any), field 2 = memo
+    # Parse TxBody manually to handle repeated messages
+    pos = 0
+    messages_raw = []
+    memo = ""
+    while pos < len(body_bytes):
+        try:
+            tag, pos = decode_varint(body_bytes, pos)
+            field_number = tag >> 3
+            wire_type = tag & 0x07
+            if wire_type == 2:
+                value, pos = decode_length_delimited(body_bytes, pos)
+                if field_number == 1:
+                    messages_raw.append(value)
+                elif field_number == 2:
+                    memo = value.decode("utf-8", errors="replace")
+            elif wire_type == 0:
+                _, pos = decode_varint(body_bytes, pos)
+            else:
+                break
+        except (IndexError, ValueError):
+            break
+
+    # Parse each message as google.protobuf.Any: field 1 = typeUrl, field 2 = value
+    for msg_any_bytes in messages_raw:
+        any_fields = parse_protobuf_strings(msg_any_bytes)
+        type_url = any_fields.get(1, b"").decode("utf-8", errors="replace")
+        if type_url != MSG_TYPE_URL:
+            continue
+
+        msg_value = any_fields.get(2, b"")
+        if not msg_value:
+            continue
+
+        # MsgRegisterContent: 1=creator, 2=contentHash, 3=license, 4=fingerprint, 5=platform
+        msg_fields = parse_protobuf_strings(msg_value)
+        creator = msg_fields.get(1, b"").decode("utf-8", errors="replace")
+        content_hash = msg_fields.get(2, b"").decode("utf-8", errors="replace")
+        license_val = msg_fields.get(3, b"").decode("utf-8", errors="replace")
+        fingerprint = msg_fields.get(4, b"").decode("utf-8", errors="replace")
+        platform = msg_fields.get(5, b"").decode("utf-8", errors="replace")
+
+        # Extract title from memo ("Register content: <title>")
+        title = ""
+        if memo.startswith("Register content: "):
+            title = memo[len("Register content: "):]
+
+        # Strip sha256: prefix for the DB column
+        db_hash = content_hash
+        if db_hash.startswith("sha256:"):
+            db_hash = db_hash[7:]
+
+        return {
+            "content_hash": db_hash,
+            "license": license_val,
+            "fingerprint": fingerprint,
+            "platform": platform,
+            "title": title,
+            "creator_address": creator,
+        }
+
+    return None
+
+
+def get_block_time(height):
+    """Get block timestamp from chain."""
+    try:
+        data = fetch_json(f"{RPC}/block?height={height}")
+        time_str = data["result"]["block"]["header"]["time"]
+        # Parse ISO timestamp
+        return time_str
+    except Exception as e:
+        print(f"  Warning: could not get block time for height {height}: {e}", file=sys.stderr)
+        return None
+
+
+def psql(sql):
+    """Run SQL via docker exec."""
+    result = subprocess.run(
+        ["docker", "exec", "-i", CONTAINER, "psql", "-U", DB_USER, "-d", DB_NAME, "-t", "-A"],
+        input=sql,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"  SQL error: {result.stderr.strip()}", file=sys.stderr)
+    return result.stdout.strip()
+
+
+def escape_sql(s):
+    """Escape a string for SQL."""
+    if s is None:
+        return "NULL"
+    return "'" + s.replace("'", "''") + "'"
+
+
+def main():
+    # Get total tx count
+    data = fetch_json(f'{RPC}/tx_search?query="tx.height>0"&per_page=1&page=1')
+    total = int(data["result"]["total_count"])
+    print(f"Total transactions on chain: {total}")
+
+    pages = (total + PER_PAGE - 1) // PER_PAGE
+    inserted = 0
+    skipped = 0
+    errors = 0
+
+    for page in range(1, pages + 1):
+        print(f"\nPage {page}/{pages}...")
+        data = fetch_json(
+            f'{RPC}/tx_search?query="tx.height>0"&per_page={PER_PAGE}&page={page}&order_by="asc"'
+        )
+        txs = data["result"]["txs"]
+
+        for tx in txs:
+            tx_hash = tx["hash"]
+            height = tx["height"]
+            tx_b64 = tx["tx"]
+
+            parsed = parse_tx(tx_b64)
+            if not parsed:
+                skipped += 1
+                continue
+
+            # Get block timestamp
+            block_time = get_block_time(height)
+
+            content_hash = parsed["content_hash"]
+            title = parsed["title"]
+            license_val = parsed["license"]
+
+            # Insert into protected_content (skip duplicates)
+            sql = f"""
+INSERT INTO protected_content (content_hash, title, license, blockchain_tx, blockchain_height, created_at, updated_at)
+VALUES ({escape_sql(content_hash)}, {escape_sql(title)}, {escape_sql(license_val)},
+        {escape_sql(tx_hash)}, {height},
+        {escape_sql(block_time) if block_time else 'NOW()'},
+        {escape_sql(block_time) if block_time else 'NOW()'})
+ON CONFLICT (content_hash) DO UPDATE SET
+    blockchain_tx = EXCLUDED.blockchain_tx,
+    blockchain_height = EXCLUDED.blockchain_height,
+    title = COALESCE(NULLIF(EXCLUDED.title, ''), protected_content.title),
+    updated_at = EXCLUDED.updated_at;
+"""
+            result = psql(sql)
+            inserted += 1
+            if inserted % 50 == 0:
+                print(f"  Processed {inserted} content registrations...")
+
+    print(f"\nReindex complete!")
+    print(f"  Inserted/updated: {inserted}")
+    print(f"  Skipped (non-content txs): {skipped}")
+
+    # Print summary
+    count = psql("SELECT count(*) FROM protected_content;")
+    print(f"  Total rows in protected_content: {count}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **Persistent volumes**: Postgres and blockchain data now bind-mount to Hetzner Cloud volumes (`/mnt/HC_Volume_103956354/`) instead of Docker named volumes, which are destroyed by `docker compose down -v`
- **Auto-init schema**: `init-production.sh` mounted into Postgres entrypoint — if the database ever starts empty, schema + all migrations load automatically
- **Daily DB backups**: `backup-db.sh` runs at 3am UTC via cron, stores compressed dumps on the second Hetzner volume with 30-day retention
- **Chain reindex script**: `reindex-from-chain.py` scans all blockchain transactions and rebuilds `protected_content` from on-chain data
- **Migration 005 fix**: `ADD CONSTRAINT IF NOT EXISTS` is invalid Postgres syntax — replaced with `DO $$ ... EXCEPTION WHEN duplicate_object` pattern
- **Gitignore**: Excludes `api-server/dist/`, `__pycache__`, Ruby vendor, load test artifacts
- **Roadmap**: AI licensing marked shipped, 2FA recovery via backup codes added at High priority

## Context
On ~April 26 the Postgres Docker volume was wiped (likely `docker compose down -v`). The database was recreated empty — no tables, no data. Magic links, content verification, and all auth endpoints were broken. Content registrations (109 unique records across 753 chain transactions) were recovered from the blockchain but user ownership mappings are permanently lost.

## Test plan
- [x] Schema loaded successfully on production (25 tables)
- [x] Reindex recovered 109 content records from 753 chain transactions
- [x] Backup script tested — produces valid compressed dump
- [x] API containers healthy, magic links functional
- [x] Verification page resolves registered content

🤖 Generated with [Claude Code](https://claude.com/claude-code)