### PR TITLE
fix(verify): enrich blockchain results with DB data; fix CD service names

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -240,8 +240,9 @@ jobs:
 
             # Stop and remove app containers so new images are guaranteed to run
             # (--force-recreate is unreliable when container_name is set)
-            docker compose stop daon-api daon-frontend daon-blockchain 2>/dev/null || true
-            docker compose rm -f daon-api daon-frontend daon-blockchain 2>/dev/null || true
+            # Service names must match docker-compose.yml (daon-api-1, daon-api-3, etc.)
+            docker compose stop daon-api-1 daon-api-3 daon-frontend daon-blockchain 2>/dev/null || true
+            docker compose rm -f daon-api-1 daon-api-3 daon-frontend daon-blockchain 2>/dev/null || true
 
             # Deploy full stack
             docker compose up -d --remove-orphans

--- a/api-server/src/server.ts
+++ b/api-server/src/server.ts
@@ -611,12 +611,13 @@ app.get('/api/v1/verify/:hash', [
     let record = null;
     let source = 'memory';
     
-    // Try blockchain first if enabled
+    // Check blockchain verification
+    let blockchainVerified = false;
     if (blockchainEnabled && blockchainClient.connected) {
       try {
         const blockchainRecord = await blockchainClient.verifyContent(hash);
-        
         if (blockchainRecord.verified) {
+          blockchainVerified = true;
           record = {
             contentHash: hash,
             timestamp: new Date(blockchainRecord.timestamp * 1000).toISOString(),
@@ -627,43 +628,45 @@ app.get('/api/v1/verify/:hash', [
           source = 'blockchain';
         }
       } catch (blockchainError) {
-        logger.warn('Blockchain verification failed, checking memory:', blockchainError.message);
+        logger.warn('Blockchain verification failed, checking database:', blockchainError.message);
       }
     }
-    
+
+    // Always check database for full record (title, AI policy, tx hash, etc.)
+    try {
+      const dbRecord = await db.content.findByHash(hash);
+      if (dbRecord) {
+        if (!record) {
+          // DB is the primary source
+          record = {
+            contentHash: hash,
+            timestamp: dbRecord.created_at,
+            license: dbRecord.license,
+            blockchain: false,
+          };
+          source = 'database';
+        }
+        // Enrich record with DB fields regardless of source
+        record.ai_training_policy = dbRecord.ai_training_policy || 'prohibited';
+        record.licensing_email = dbRecord.licensing_email || null;
+        record.metadata = {
+          title: dbRecord.title,
+          type: dbRecord.content_type,
+          description: dbRecord.description,
+        };
+        record.verificationUrl = dbRecord.verification_url || generateVerificationUrl(hash);
+        record.blockchainTx = dbRecord.blockchain_tx;
+        record.blockchainHeight = dbRecord.blockchain_height;
+      }
+    } catch (dbError) {
+      logger.warn('DB verification lookup failed:', (dbError as any).message);
+    }
+
     // Fall back to in-memory cache
     if (!record) {
       record = protectedContent.get(hash);
       if (record) {
         source = 'memory-cache';
-      }
-    }
-
-    // Fall back to database (shared across all instances)
-    if (!record) {
-      try {
-        const dbRecord = await db.content.findByHash(hash);
-        if (dbRecord) {
-          record = {
-            contentHash: hash,
-            timestamp: dbRecord.created_at,
-            license: dbRecord.license,
-            ai_training_policy: dbRecord.ai_training_policy || 'prohibited',
-            licensing_email: dbRecord.licensing_email || null,
-            licensing_uri: dbRecord.licensing_uri || null,
-            metadata: {
-              title: dbRecord.title,
-              type: dbRecord.content_type,
-              description: dbRecord.description,
-            },
-            verificationUrl: dbRecord.verification_url || generateVerificationUrl(hash),
-            blockchainTx: dbRecord.blockchain_tx,
-            blockchainHeight: dbRecord.blockchain_height,
-          };
-          source = 'database';
-        }
-      } catch (dbError) {
-        logger.warn('DB verification lookup failed:', (dbError as any).message);
       }
     }
 


### PR DESCRIPTION
## Summary
- **Verify endpoint**: Always queries the DB to enrich records even when blockchain verifies first. Previously, title, AI training policy, tx hash, and block height were null on blockchain-verified content because the DB was only used as a fallback.
- **CD pipeline**: Fixed service names from `daon-api` to `daon-api-1`/`daon-api-3` in deploy.yml. The old names didn't match any services, so `docker compose stop/rm` was silently no-opping and containers were never recreated on deploy.

## Test plan
- [ ] CI passes
- [ ] Verify endpoint returns title, ai_training_policy, blockchain.txHash, blockchain.height for a known hash
- [ ] Deploy actually recreates API containers (check `docker ps` shows fresh creation time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)