### PR TITLE
fix(deps): point Renovate at main so it actually runs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "baseBranches": ["develop"],
+  "baseBranches": ["main"],
+  "dependencyDashboard": true,
   "labels": ["dependencies"],
   "reviewers": ["@daon-network/maintainers"],
   "schedule": ["every monday at 6am"],


### PR DESCRIPTION
One line. `renovate.json` has targeted `develop` since April — **a branch that has never existed in this repo.**

Renovate has therefore opened **0 PRs in four months**. No dependency dashboard, no `renovate/*` branches, nothing. It's installed and it has had nothing to scan.

## The April migration was right

From `5672ec2`:

> *"Dependabot groups unrelated npm majors into single PRs and skips lockfile regeneration, causing npm ci failures. Renovate handles npm monorepos correctly: runs npm install per directory, keeps lockfiles in sync, and isolates major bumps per package."*

That is **exactly** the failure still happening today. #88 and #95 are both dead on `npm ci`:

```
npm error EUSAGE
npm error Invalid: lock file's eslint@8.57.1 does not satisfy eslint@10.8.1
npm error Missing: vite@8.2.1 from lock file
```

The diagnosis was correct. The migration just never took effect.

## And one thing that compounded it

The follow-up commit `5265952` recorded that deleting `.github/dependabot.yml` *"stops Dependabot entirely."* **It doesn't.**

`dependabot.yml` governs **version updates** only. **Security updates** are a separate repository setting, and they stayed on. So the configured, grouped updates were switched off and the unconfigured ones left running — the worst half of the pair, and the source of every broken PR since.

| | State before this PR |
| --- | --- |
| Renovate | configured, pointed at a nonexistent branch → doing nothing |
| Dependabot version updates | config deleted → off |
| Dependabot security updates | never touched → on, unconfigured, generating broken PRs |

## This PR

- `baseBranches: ["develop"]` → `["main"]`
- `dependencyDashboard: true` — so Renovate reports its intent in a tracking issue. Had that been on, four silent months would have been obvious within one.

## Follow-up, in this order

1. Merge this and confirm Renovate opens its dashboard issue / first PR
2. **Then** disable Dependabot security updates in Settings → Code security

Doing step 2 first would leave no dependency automation at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)