### PR TITLE
fix(build): raise Go builder images to 1.25 to match go.mod

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -131,14 +131,47 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          # Read the version from go.mod so this can never drift from it.
+          go-version-file: daon-core/go.mod
       - name: Build blockchain binary
+        # GOTOOLCHAIN=local matches the Docker builder, which cannot reach the
+        # network to fetch a newer toolchain. Without it setup-go silently
+        # downloads whatever go.mod asks for, so this job passes while the
+        # release build fails -- exactly what happened on #98.
+        env:
+          GOTOOLCHAIN: local
         run: |
           cd daon-core
           go mod download
           make install || go build -o build/daon-cored ./cmd/daon-cored
       - name: Test blockchain binary
         run: cd daon-core && ./build/daon-cored version || echo "Binary created successfully"
+
+  blockchain-docker-build:
+    name: Blockchain Docker Build
+    needs: [changes, blockchain-build-test]
+    # Mirrors the "Build Validator Image" job in deploy.yml -- same context and
+    # platforms -- so a release build cannot fail in a way this job passes.
+    # deploy.yml only triggers on push to main, so before this job existed the
+    # image was first built after merge, and a bad build took production with it.
+    if: |
+      always() &&
+      needs.changes.outputs.blockchain == 'true' &&
+      needs.blockchain-build-test.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Build validator image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./daon-core
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: daonnetwork/validator:pr-${{ github.event.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   # ── Frontend ──────────────────────────────────────────────────────────────
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -150,10 +150,18 @@ jobs:
   blockchain-docker-build:
     name: Blockchain Docker Build
     needs: [changes, blockchain-build-test]
-    # Mirrors the "Build Validator Image" job in deploy.yml -- same context and
-    # platforms -- so a release build cannot fail in a way this job passes.
-    # deploy.yml only triggers on push to main, so before this job existed the
-    # image was first built after merge, and a bad build took production with it.
+    # Builds the real validator image from the same context deploy.yml uses, so
+    # a Dockerfile, toolchain or dependency-resolution failure surfaces here
+    # rather than after merge. deploy.yml only triggers on push to main, so
+    # before this job existed the image was first built post-merge.
+    #
+    # amd64 only, deliberately. The release build does amd64 and arm64, but
+    # arm64 runs under qemu and takes over 25 minutes for a cosmos-sdk chain --
+    # go mod download and a full compile, emulated. Native amd64 takes minutes
+    # and catches the same failures, all of which are architecture independent.
+    # An arm64-only regression cannot reach production regardless: deploy.yml
+    # gates deployment on its own multi-arch build, so it would fail there the
+    # way #98 did, with nothing shipped.
     if: |
       always() &&
       needs.changes.outputs.blockchain == 'true' &&
@@ -161,13 +169,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - name: Build validator image
         uses: docker/build-push-action@v5
         with:
           context: ./daon-core
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: false
           tags: daonnetwork/validator:pr-${{ github.event.number }}
           cache-from: type=gha

--- a/ccc-core/Dockerfile
+++ b/ccc-core/Dockerfile
@@ -2,7 +2,7 @@
 # This image will be published to Docker Hub for easy validator deployment
 
 # Multi-stage build for optimized production image
-FROM golang:1.21-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git make gcc musl-dev

--- a/daon-core/Dockerfile
+++ b/daon-core/Dockerfile
@@ -1,7 +1,7 @@
 # DAON Blockchain Node - Docker Image for Production Deployment
 # Multi-stage build for optimized production image
 
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates

--- a/daon-core/ccc-core/Dockerfile
+++ b/daon-core/ccc-core/Dockerfile
@@ -2,7 +2,7 @@
 # This image will be published to Docker Hub for easy validator deployment
 
 # Multi-stage build for optimized production image
-FROM golang:1.24rc1-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git make gcc musl-dev


### PR DESCRIPTION
**Fixes the production deploy that my #98 broke.**

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
ERROR: process "/bin/sh -c go mod download" did not complete successfully
```

## Cause

Updating the Go modules in #98 pulled OpenTelemetry forward as a transitive dependency of `google.golang.org/grpc`. `go.opentelemetry.io/otel` and its `sdk` / `metric` / `trace` packages **require go 1.25.0**, so `go mod tidy` raised the `go` directive from `1.24.0` to `1.25.0` across all four workspaces.

Reverting the directive isn't an option — `tidy` restores it immediately, because the requirement is real. Verified by trying it.

The builder images simply hadn't moved with it.

## Fix

| Dockerfile | Before | After |
| --- | --- | --- |
| `daon-core/` | `golang:1.24-alpine` | `golang:1.25-alpine` |
| `ccc-core/` | `golang:1.21-alpine` | `golang:1.25-alpine` |
| `daon-core/ccc-core/` | `golang:1.24rc1-alpine` | `golang:1.25-alpine` |

**Only `daon-core` caused the deploy failure.** The other two were already inconsistent before this branch — `ccc-core` built on 1.21 against a go.mod asking for 1.24, and `daon-core/ccc-core` was pinned to **`1.24rc1`, a release candidate, in an image that ships to production.** Both are corrected here rather than left to fail the next time either gets built.

## Verification

Ran with `GOTOOLCHAIN=local` on go1.25.5 — the same constraint the builder enforces, which is what made the failure reproducible:

```
go mod download   exit 0
go build ./...    exit 0
```

Docker isn't running locally, so the image build itself is unverified. **CI on this PR is the check that matters** — specifically `Build Validator Image`, which is where it failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)