### PR TITLE
feat(provenance): the four-step minimum verifier

### DIFF
--- a/provenance/Cargo.lock
+++ b/provenance/Cargo.lock
@@ -37,10 +37,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "daon-provenance-core"
 version = "0.0.0"
 dependencies = [
  "sha2",
+]
+
+[[package]]
+name = "daon-provenance-verify"
+version = "0.0.0"
+dependencies = [
+ "daon-provenance-core",
+ "ed25519-dalek",
 ]
 
 [[package]]
@@ -52,6 +86,33 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "generic-array"
@@ -70,6 +131,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,10 +175,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "version_check"

--- a/provenance/Cargo.toml
+++ b/provenance/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["core"]
+members = ["core", "verify"]
 
 [workspace.package]
 edition = "2021"
@@ -10,3 +10,5 @@ repository = "https://github.com/daon-network/daon"
 
 [workspace.dependencies]
 sha2 = { version = "0.10", default-features = false }
+ed25519-dalek = { version = "2", default-features = false }
+daon-provenance-core = { path = "core", default-features = false }

--- a/provenance/core/src/lib.rs
+++ b/provenance/core/src/lib.rs
@@ -268,6 +268,15 @@ impl RevisionLeaf {
     }
 }
 
+/// Hash bytes under a domain separation tag: `SHA256(tag || bytes)`.
+///
+/// Exposed so downstream crates can recompute a tagged hash — a content segment,
+/// say — without taking a direct dependency on a hash implementation. Keeping the
+/// verifier's dependency surface small is a design goal, not an accident.
+pub fn hash_tagged(tag: u8, bytes: &[u8]) -> Hash {
+    sha256(&[&[tag], bytes])
+}
+
 /// Hash arbitrary bytes as a Merkle leaf: `SHA256(0x00 || bytes)`.
 ///
 /// Callers building a log of revisions want [`RevisionLeaf::leaf_id`]; this is

--- a/provenance/verify/Cargo.toml
+++ b/provenance/verify/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "daon-provenance-verify"
+version = "0.0.0"          # not published; the wire format is not frozen yet
+description = "The four-step minimum verifier for DAON provenance claims"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+daon-provenance-core.workspace = true
+ed25519-dalek = { workspace = true, optional = true }
+
+[features]
+default = ["std", "signatures"]
+std = ["daon-provenance-core/std"]
+# Step 4 only. Steps 1-3 must keep working without it, so a verifier that does
+# not care about authorship can be built smaller.
+signatures = ["dep:ed25519-dalek"]

--- a/provenance/verify/src/lib.rs
+++ b/provenance/verify/src/lib.rs
@@ -1,0 +1,186 @@
+//! The four-step minimum verifier for DAON provenance claims.
+//!
+//! From `docs/design/provenance-data-model.md`, given `(leaf, inclusion_proof,
+//! witness_receipt)`:
+//!
+//! 1. Recompute the leaf hash from disclosed fields.
+//! 2. Walk `inclusion_proof` from leaf → `witnessed_head` — O(log n).
+//! 3. Verify the witness attestation resolves to a Bitcoin block ≥ `witness_time`.
+//! 4. *(optional)* Verify the author signature on the leaf.
+//!
+//! > One trusted anchor. One log-depth walk. Constant in leaf count. Multi-witness,
+//! > consistency chains, selective-disclosure ZK and fork traversal are **later
+//! > features, never part of this path.**
+//!
+//! That instruction is why this crate exists separately from anything that stores,
+//! coalesces or witnesses. Keeping the verifier small is a design goal with teeth:
+//! it is the thing a skeptic runs, and every dependency it grows is something they
+//! have to trust or audit.
+//!
+//! # What this crate does not decide
+//!
+//! Step 3 takes an already-established [`WitnessAttestation`]. Parsing an
+//! OpenTimestamps proof and resolving it against Bitcoin headers is a distinct
+//! trust anchor with its own failure modes, and folding it in here would mean a
+//! verifier that cannot run without a chain source. Separating them lets a
+//! relying party choose how they establish Bitcoin state — their own node, a
+//! header chain they already trust, or an OTS client — without this crate having
+//! an opinion.
+//!
+//! **A caller that fabricates an attestation gets a meaningless answer.** That is
+//! stated rather than defended against, because it cannot be defended against
+//! here: the verifier's job is to check a claim against an anchor, not to decide
+//! what anchors are real.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+extern crate alloc;
+use daon_provenance_core::{hash_tagged, tag, verify_inclusion, Hash, ProofStep, RevisionLeaf};
+
+/// An established statement that a head existed by a given time.
+///
+/// Existence and ordering only. A witness attests that these bytes existed by
+/// this time — never anything about who made them, how, or whether the content
+/// is any good.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WitnessAttestation {
+    /// The head this attestation covers.
+    pub witnessed_head: Hash,
+    /// Unix milliseconds. The upper time bound for every leaf beneath the head.
+    pub witness_time_ms: i64,
+}
+
+/// Why a claim did not verify.
+///
+/// Each variant names the step that failed, so a caller can report something
+/// more useful than "invalid".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Failure {
+    /// Step 2: the inclusion proof does not fold to the witnessed head.
+    NotInWitnessedHead,
+    /// Step 3: the attestation covers a different head than the proof reaches.
+    AttestationHeadMismatch,
+    /// Step 3: the leaf claims a beacon later than the witness time, so the
+    /// sandwich is inverted and no honest leaf could sit here.
+    TimeBoundsInverted,
+    /// Step 4: the signature does not verify under the leaf's `author_key`.
+    #[cfg(feature = "signatures")]
+    BadSignature,
+    /// Step 4 was requested but the key is not a valid Ed25519 point.
+    #[cfg(feature = "signatures")]
+    MalformedAuthorKey,
+    /// Step 4 was requested of a verifier built without signature support.
+    #[cfg(not(feature = "signatures"))]
+    SignaturesUnsupported,
+}
+
+/// What a successful verification establishes — and, as importantly, what it does not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Verified {
+    /// This leaf existed no later than here.
+    pub existed_by_ms: i64,
+    /// Whether step 4 ran. `false` means existence is proven but authorship is not
+    /// — a distinction a caller must not flatten.
+    pub author_signature_checked: bool,
+}
+
+/// A claim to be checked.
+pub struct Claim<'a> {
+    /// The leaf, with whatever fields the holder disclosed.
+    pub leaf: &'a RevisionLeaf,
+    /// Sibling hashes from the leaf to the witnessed head.
+    pub proof: &'a [ProofStep],
+    /// The head the proof should reach.
+    pub head: Hash,
+    /// An established witness statement about that head.
+    pub attestation: WitnessAttestation,
+    /// Ed25519 signature over the leaf id. `None` skips step 4.
+    pub signature: Option<&'a [u8; 64]>,
+}
+
+/// Run the four steps.
+///
+/// Returns what was established, or the first step that failed. Steps run in
+/// order and stop at the first failure, so the error names the earliest thing
+/// wrong rather than an arbitrary one.
+pub fn verify(claim: &Claim<'_>) -> Result<Verified, Failure> {
+    // Step 1 — recompute the leaf hash from disclosed fields.
+    let leaf_id = claim.leaf.leaf_id();
+
+    // Step 2 — walk the proof to the witnessed head.
+    if !verify_inclusion(&leaf_id, claim.proof, &claim.head) {
+        return Err(Failure::NotInWitnessedHead);
+    }
+
+    // Step 3 — the attestation must be about the head we actually reached.
+    if claim.attestation.witnessed_head != claim.head {
+        return Err(Failure::AttestationHeadMismatch);
+    }
+
+    // The beacon's lower bound is checked by `beacon_lower_bound`, not here:
+    // resolving a block height to a timestamp needs a chain source, and the
+    // minimum verifier does not get to require one.
+    let existed_by_ms = claim.attestation.witness_time_ms;
+
+    // Step 4 — optional.
+    let author_signature_checked = match claim.signature {
+        None => false,
+        Some(sig) => {
+            check_signature(&claim.leaf.author_key, &leaf_id, sig)?;
+            true
+        }
+    };
+
+    Ok(Verified {
+        existed_by_ms,
+        author_signature_checked,
+    })
+}
+
+/// Check the beacon sandwich once a caller has resolved the beacon block to a time.
+///
+/// Separate from [`verify`] because resolving a block height to a timestamp needs
+/// a chain source, and the minimum verifier does not get to require one. A caller
+/// that can resolve it should call this too; one that cannot still gets steps 1, 2
+/// and 4.
+pub fn beacon_lower_bound(
+    beacon_time_ms: i64,
+    attestation: &WitnessAttestation,
+) -> Result<(), Failure> {
+    if beacon_time_ms > attestation.witness_time_ms {
+        return Err(Failure::TimeBoundsInverted);
+    }
+    Ok(())
+}
+
+#[cfg(feature = "signatures")]
+fn check_signature(author_key: &Hash, leaf_id: &Hash, sig: &[u8; 64]) -> Result<(), Failure> {
+    use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+    let key = VerifyingKey::from_bytes(author_key).map_err(|_| Failure::MalformedAuthorKey)?;
+    key.verify(leaf_id, &Signature::from_bytes(sig))
+        .map_err(|_| Failure::BadSignature)
+}
+
+#[cfg(not(feature = "signatures"))]
+fn check_signature(_: &Hash, _: &Hash, _: &[u8; 64]) -> Result<(), Failure> {
+    // Fail closed. Returning Ok here would report author_signature_checked: true
+    // having verified nothing at all -- a build without the feature would silently
+    // accept any signature. A caller asking for step 4 in a verifier that cannot
+    // perform step 4 must be told so.
+    Err(Failure::SignaturesUnsupported)
+}
+
+/// Prove one content segment against a leaf's `content_commit`.
+///
+/// This is a **creator-initiated** disclosure. DAON issues no endpoint taking a
+/// segment index and no certificate rendering one; a holder produces this from
+/// content only they possess and hands it to whoever they choose.
+///
+/// Callers must not treat a missing segment proof as meaningful. Declining to
+/// disclose is the default, not an admission.
+pub fn verify_segment(segment_bytes: &[u8], proof: &[ProofStep], content_commit: &Hash) -> bool {
+    let leaf = hash_tagged(tag::CONTENT, segment_bytes);
+    verify_inclusion(&leaf, proof, content_commit)
+}

--- a/provenance/verify/tests/verifier.rs
+++ b/provenance/verify/tests/verifier.rs
@@ -1,0 +1,239 @@
+//! Tests for the four-step minimum verifier.
+//!
+//! Most of these are negative. A verifier that accepts good claims is easy; the
+//! whole value is in what it refuses, so every step gets a test that breaks it.
+
+use daon_provenance_core::*;
+use daon_provenance_verify::*;
+
+fn leaf_at(seq: u64, content: &[u8]) -> RevisionLeaf {
+    RevisionLeaf {
+        seq,
+        parent_head: [0u8; 32],
+        content_commit: content_commit(content),
+        meta_commit: meta_commit(&[Observation {
+            tool_id: b"test/1.0".to_vec(),
+            ingress: Ingress::KeystrokeStream,
+            added: 100,
+            removed: 0,
+            duration_ms: 5000,
+            op_count: 40,
+        }])
+        .unwrap(),
+        beacon: Beacon {
+            chain: BeaconChain::Bitcoin,
+            height: 880_000,
+            block_hash: [0xab; 32],
+        },
+        author_key: [0x11u8; 32],
+        recovery_key: [0x22u8; 32],
+        local_time_ms: 1_754_000_000_000,
+    }
+}
+
+/// A small log with a real head and proofs, as an agent would produce.
+fn log_of(n: u64) -> (Vec<RevisionLeaf>, Vec<Hash>, Hash) {
+    let leaves: Vec<RevisionLeaf> = (0..n).map(|i| leaf_at(i, b"some content")).collect();
+    let ids: Vec<Hash> = leaves.iter().map(|l| l.leaf_id()).collect();
+    let head = merkle_root(&ids);
+    (leaves, ids, head)
+}
+
+#[test]
+fn a_good_claim_verifies() {
+    let (leaves, ids, head) = log_of(5);
+    let proof = inclusion_proof(&ids, 3);
+    let out = verify(&Claim {
+        leaf: &leaves[3],
+        proof: &proof,
+        head,
+        attestation: WitnessAttestation {
+            witnessed_head: head,
+            witness_time_ms: 1_754_000_900_000,
+        },
+        signature: None,
+    })
+    .expect("should verify");
+
+    assert_eq!(out.existed_by_ms, 1_754_000_900_000);
+    assert!(
+        !out.author_signature_checked,
+        "no signature supplied, so authorship is not established"
+    );
+}
+
+#[test]
+fn step2_a_leaf_not_under_the_head_is_refused() {
+    let (leaves, ids, head) = log_of(5);
+    let proof = inclusion_proof(&ids, 3);
+    // Same proof, different leaf.
+    let err = verify(&Claim {
+        leaf: &leaves[2],
+        proof: &proof,
+        head,
+        attestation: WitnessAttestation {
+            witnessed_head: head,
+            witness_time_ms: 1_754_000_900_000,
+        },
+        signature: None,
+    })
+    .unwrap_err();
+    assert_eq!(err, Failure::NotInWitnessedHead);
+}
+
+#[test]
+fn step2_a_tampered_leaf_is_refused() {
+    let (leaves, ids, head) = log_of(5);
+    let proof = inclusion_proof(&ids, 1);
+    let mut tampered = leaves[1].clone();
+    tampered.local_time_ms += 1; // one field, one millisecond
+
+    let err = verify(&Claim {
+        leaf: &tampered,
+        proof: &proof,
+        head,
+        attestation: WitnessAttestation {
+            witnessed_head: head,
+            witness_time_ms: 1_754_000_900_000,
+        },
+        signature: None,
+    })
+    .unwrap_err();
+    assert_eq!(
+        err,
+        Failure::NotInWitnessedHead,
+        "changing any hashed field must break inclusion"
+    );
+}
+
+#[test]
+fn step3_an_attestation_about_another_head_is_refused() {
+    let (leaves, ids, head) = log_of(5);
+    let proof = inclusion_proof(&ids, 0);
+    let err = verify(&Claim {
+        leaf: &leaves[0],
+        proof: &proof,
+        head,
+        attestation: WitnessAttestation {
+            witnessed_head: [0xff; 32], // a head this proof never reaches
+            witness_time_ms: 1_754_000_900_000,
+        },
+        signature: None,
+    })
+    .unwrap_err();
+    assert_eq!(err, Failure::AttestationHeadMismatch);
+}
+
+#[test]
+fn beacon_sandwich_rejects_inverted_bounds() {
+    let att = WitnessAttestation {
+        witnessed_head: [0u8; 32],
+        witness_time_ms: 1_000,
+    };
+    assert!(
+        beacon_lower_bound(999, &att).is_ok(),
+        "beacon before witness is fine"
+    );
+    assert!(beacon_lower_bound(1_000, &att).is_ok(), "equal is fine");
+    assert_eq!(
+        beacon_lower_bound(1_001, &att).unwrap_err(),
+        Failure::TimeBoundsInverted,
+        "a leaf cannot predate a beacon it names while being witnessed earlier"
+    );
+}
+
+#[test]
+fn segment_disclosure_verifies_and_rejects_tampering() {
+    // Three distinct 1 KiB segments. Distinct matters: identical segments would
+    // make a substituted-segment proof appear to verify, which is how a fixture
+    // hides a real bug.
+    let doc: Vec<u8> = [1u8, 2, 3]
+        .iter()
+        .flat_map(|b| core::iter::repeat_n(*b, 1024))
+        .collect();
+    let commit = content_commit(&doc);
+    let segs = segments(&doc);
+    let seg_leaves: Vec<Hash> = segs.iter().map(|s| hash_tagged(tag::CONTENT, s)).collect();
+    let proof = inclusion_proof(&seg_leaves, 1);
+
+    assert!(verify_segment(segs[1], &proof, &commit));
+    assert!(
+        !verify_segment(segs[2], &proof, &commit),
+        "a different segment under this proof must not verify"
+    );
+    assert!(
+        !verify_segment(&[0u8; 1024], &proof, &commit),
+        "tampered content must not verify"
+    );
+}
+
+#[cfg(feature = "signatures")]
+mod signatures {
+    use super::*;
+
+    #[test]
+    fn a_garbage_signature_is_refused() {
+        let (leaves, ids, head) = log_of(3);
+        let proof = inclusion_proof(&ids, 0);
+        let sig = [0u8; 64];
+        let err = verify(&Claim {
+            leaf: &leaves[0],
+            proof: &proof,
+            head,
+            attestation: WitnessAttestation {
+                witnessed_head: head,
+                witness_time_ms: 1_754_000_900_000,
+            },
+            signature: Some(&sig),
+        })
+        .unwrap_err();
+        // author_key here is 0x11 repeated, which is not a valid Ed25519 point,
+        // so this fails at key parsing rather than at signature checking. Either
+        // way it must not report success.
+        assert!(
+            err == Failure::MalformedAuthorKey || err == Failure::BadSignature,
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn steps_one_to_three_do_not_require_a_signature() {
+        let (leaves, ids, head) = log_of(3);
+        let proof = inclusion_proof(&ids, 2);
+        let out = verify(&Claim {
+            leaf: &leaves[2],
+            proof: &proof,
+            head,
+            attestation: WitnessAttestation {
+                witnessed_head: head,
+                witness_time_ms: 42,
+            },
+            signature: None,
+        })
+        .unwrap();
+        assert!(!out.author_signature_checked);
+    }
+}
+
+/// Without signature support, asking for step 4 must fail rather than silently
+/// pass. An earlier draft returned `Ok` here, which would have reported
+/// `author_signature_checked: true` having verified nothing.
+#[cfg(not(feature = "signatures"))]
+#[test]
+fn a_verifier_without_signature_support_fails_closed() {
+    let (leaves, ids, head) = log_of(3);
+    let proof = inclusion_proof(&ids, 0);
+    let sig = [0u8; 64];
+    let err = verify(&Claim {
+        leaf: &leaves[0],
+        proof: &proof,
+        head,
+        attestation: WitnessAttestation {
+            witnessed_head: head,
+            witness_time_ms: 1,
+        },
+        signature: Some(&sig),
+    })
+    .unwrap_err();
+    assert_eq!(err, Failure::SignaturesUnsupported);
+}


### PR DESCRIPTION
> Stacked on #102. Review that first; this diff is only the `verify` crate.

Implements the verifier the data model says to protect:

1. Recompute the leaf hash from disclosed fields
2. Walk the inclusion proof to the witnessed head — O(log n)
3. Check the attestation covers that head
4. *(optional)* Check the author signature

One trusted anchor, one log-depth walk, constant in leaf count.

| | |
| --- | --- |
| Tests | **8 with signatures, 7 without** — both configurations |
| clippy | 0 warnings |
| `wasm32-unknown-unknown` | builds, both feature sets |
| Dependency tree | `sha2`, plus `ed25519-dalek` for step 4 only |

Separate crate because keeping it small is a design goal with teeth. **It's the thing a skeptic runs**, and every dependency it grows is something they have to audit.

## Two bugs in my own first draft

Both caught by writing the negative tests, which is most of what's here.

**A verifier built without `signatures` accepted any signature.** `check_signature` returned `Ok` when the feature was off, so a caller supplying a signature got `author_signature_checked: true` having verified *nothing*. It now fails closed with `SignaturesUnsupported` — asking for step 4 of a verifier that cannot do step 4 must be an error, not a silent pass. There's a test in the no-signatures configuration that would have caught it.

**`Failure::LeafIdMismatch` was unreachable.** Step 1 *derives* the leaf id from disclosed fields; it never compares against a presented one, so there's nothing to mismatch. A dead error variant misleads about what can fail.

## What step 3 deliberately doesn't do

It takes an already-established `WitnessAttestation` rather than parsing OpenTimestamps proofs.

Resolving an OTS proof against Bitcoin headers is a distinct trust anchor with its own failure modes, and folding it in would mean **a verifier that cannot run without a chain source**. Separating them lets a relying party establish Bitcoin state however they already do — their own node, a header chain they trust, an OTS client — while this crate stays runnable anywhere.

A caller that fabricates an attestation gets a meaningless answer. That's stated in the docs rather than defended against, because it can't be defended against here: the verifier checks a claim against an anchor; it doesn't decide which anchors are real.

`beacon_lower_bound` is separate for the same reason — the sandwich needs a block height resolved to a time, and the minimum verifier doesn't get to require a chain source. A caller who can resolve it should; one who can't still gets steps 1, 2 and 4.

## Tests are mostly negative

A verifier that accepts good claims is easy. The value is in what it refuses:

- a leaf not under the head, using a valid proof for a *different* leaf
- a tampered leaf — `local_time_ms += 1`, one field, one millisecond
- an attestation about a head the proof never reaches
- inverted time bounds (beacon later than witness)
- a substituted content segment, and tampered segment bytes

The segment test uses three genuinely **distinct** 1 KiB segments. Identical ones would make a substituted-segment proof appear to verify — the fixture bug from the spec work, kept out deliberately.

## Not in this change

Packaging an actual `.wasm` artifact needs a cdylib wrapper, so **no size claim is made here** — only that both feature sets compile for the target.

Next is the agent: key handling, coalescing, rate limits, OTS batching. That's where the enforcement lives and it's the piece with real I/O and state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)