### PR TITLE
docs: key authorization — which keys may extend an entity

### DIFF
--- a/docs/design/editor-integration-spec.md
+++ b/docs/design/editor-integration-spec.md
@@ -435,7 +435,9 @@ ours to close.
   no longer constrains anything an adjudicator has to reproduce.
 - **Key loss.** Losing the author key ends the ability to append to an entity; history stays
   verifiable but frozen. Needs a recovery story before anyone depends on this.
-- **Multi-device.** Out of MVP scope (single-writer), but the `seq`/`parent_head` shape should be
-  checked against a future where two devices append to one entity.
+- **Multi-device.** Was listed here as out of scope under "single-writer", which conflated two
+  different things: single-*writer* (no concurrent authors) is deferrable, single-*device* never
+  described real writing. See [`key-authorization.md`](./key-authorization.md) — the question is
+  which keys may extend an entity, and it must be settled before the agent is built.
 - **Limit defaults.** The §5 numbers are reasoned, not measured. Revisit against real editing
   traffic once instrumented.

--- a/docs/design/key-authorization.md
+++ b/docs/design/key-authorization.md
@@ -1,0 +1,190 @@
+# Key Authorization — Which Keys May Extend an Entity
+
+**Status:** design proposal, pre-`0.1.0` · **Decision required before the agent is built**
+**Companion to:** [`wire-format.md`](./wire-format.md), [`provenance-data-model.md`](./provenance-data-model.md)
+
+---
+
+## The question
+
+An entity's chain is extended by leaves signed by a private key. The format has exactly one
+`author_key` field and no mechanism saying another key may also append. That is fine for one
+writer on one machine forever, and that describes nobody.
+
+Three pressures arrive at the same question:
+
+| | |
+| --- | --- |
+| **Multi-device** | A writer drafts on a laptop and fixes a line on a phone. Both are the same person and the same manuscript. |
+| **Key loss** | `recovery_key` is reserved precisely so a lost key does not freeze a chain — but "reserved" means its semantics are undefined. |
+| **Hardware keys** | Secure Enclave keys are non-extractable and device-bound. Using one means accepting more than one key per entity. |
+
+These are one question — *which keys may extend this chain* — and answering them separately would
+produce two mechanisms that must then agree.
+
+## A scoping error worth naming
+
+The specs list multi-device as out of MVP scope, "single-writer." That conflated two things:
+
+- **Single-writer** — no concurrent authors, no merge semantics. Genuinely deferrable.
+- **Single-device** — never true of real writing.
+
+A solo writer moving between their own devices is the normal case. It was scoped out by accident.
+
+## The constraint everything must respect
+
+> One trusted anchor. One log-depth walk. Constant in leaf count. Multi-witness, consistency
+> chains, selective-disclosure ZK, and fork traversal are **later features, never part of this
+> path.**
+
+Any design that makes the verifier walk a chain of authorizations to decide whether a signature
+counts has spent the thing the data model says to protect. That is the bar.
+
+## What the witnessed head already gives us
+
+Worth stating because it removes an attack people reach for first.
+
+A verifier that trusts a witnessed head trusts that **every leaf beneath it existed when it was
+witnessed.** An attacker cannot retroactively insert an authorization leaf into a witnessed head
+— that would require finding a SHA-256 collision, or rewriting Bitcoin.
+
+So the question is never "could this authorization have been forged into the past." It is only
+"among the leaves under a head I already trust, was this signature made by a key that was allowed
+to sign."
+
+---
+
+## Option A — One key, moved deliberately
+
+The format is unchanged. An entity has one key for its lifetime. Multi-device is solved by the
+creator moving the key: an export/import ceremony, a QR code, an encrypted file.
+
+| | |
+| --- | --- |
+| Verifier | **unchanged — four steps** |
+| Format | **unchanged** |
+| Secure Enclave | impossible; the key must be movable |
+| Multi-device | works, with friction the creator performs deliberately |
+| Key loss | `recovery_key`, semantics still to define |
+| Cross-platform | complete — nothing vendor-specific |
+
+The friction is real, and it is also legible: the creator knows exactly when their key moved,
+because they moved it. Nothing syncs behind their back.
+
+## Option B — One key, synced by the platform
+
+As A, but iCloud Keychain (or equivalent) moves the key between the creator's devices.
+
+Same properties as A except: no friction, and a dependency on a vendor's sync with a vendor's
+threat model. Apple-only; Android and Linux need a different answer, so the project ends up
+maintaining A anyway as the portable path.
+
+**A and B are the same protocol.** B is a convenience layer over A, not a separate design, and
+can be added or dropped without touching the format.
+
+## Option C — Key set committed in every leaf
+
+Add `key_set_root` to the leaf: a Merkle root over the public keys currently authorized. A leaf
+is valid if its signature verifies under a key proven to be a member of *its own* `key_set_root`.
+
+Verification becomes:
+
+```
+1. recompute leaf id
+2. inclusion proof: leaf → witnessed head        (existing)
+3. attestation covers that head                  (existing)
+4. signature verifies under key K                (existing, optional)
+5. membership proof: K → leaf.key_set_root       (new — same machinery as 2)
+```
+
+Step 5 is a Merkle inclusion walk against a root already in the leaf. Local, O(log keys), no
+chain traversal. It reuses the tree code that already exists.
+
+| | |
+| --- | --- |
+| Verifier | **five steps**, but the fifth is the same *kind* as the second |
+| Format | +32 bytes per leaf; every vector regenerates |
+| Secure Enclave | **works** — each device enrols its own non-extractable key |
+| Multi-device | native |
+| Key loss | a recovery key is simply another set member |
+| Cross-platform | complete |
+
+### What it does not establish
+
+Step 5 proves a signature came from a key the leaf *claims* is authorized. It does not prove the
+claim is legitimate — a leaf could name any key set. Establishing that a set was legitimately
+derived from the previous one requires walking back toward genesis, which is the cost the
+constraint forbids.
+
+For the case that matters this is acceptable, and the reason is worth being precise about: the
+leaf is under a head the verifier already trusts, so it was placed there by whoever controlled the
+entity at the time. A creator who adds a key to their own chain has done exactly what the
+mechanism is for. The residual risk is an *attacker who has already compromised the entity*
+adding their own key — and an attacker who can append to your chain has already won, regardless
+of what step 5 says.
+
+The property genuinely lost is **retrospective auditability of the key set** — "when was this key
+added, and by whom" is answerable only by walking the chain. That is a P1 tool, not a verifier
+step.
+
+## Option D — Device-bound entities
+
+Each device gets its own entity; lineage between them is expressed by forks (P2).
+
+Cheapest to build, and it fragments a single manuscript across devices while forks are still
+unspecified. A writer would see one work as several unrelated chains. Recorded for completeness.
+
+---
+
+## Recommendation
+
+**Option A now, with C's shape kept possible.**
+
+The reasoning is priority order rather than a claim that C is worse:
+
+**The verifier is the thing being protected.** A is the only option that leaves it at four steps.
+C's fifth step is cheap and reuses existing machinery, but "five steps, one of which is
+conditional" is a different artifact from "four steps," and the design says to protect the four.
+
+**Recovery outranks theft-resistance here, and that was already decided.** `recovery_key` exists
+because a frozen chain is a real harm — a fourteen-month dissertation stopping dead. Secure
+Enclave maximises theft-resistance by making loss *permanent*, which is the failure mode we
+deliberately designed against. Hardware binding is a weaker fit for this project than it first
+appears.
+
+**A works everywhere; C's main prize does not.** Secure Enclave is Apple; StrongBox is Android and
+inconsistently available. A creator on Linux gets a software key either way. Paying a format
+change for a benefit that reaches some platforms is a poor trade.
+
+**A is reversible; the format change is not.** Adding `key_set_root` later is a version bump —
+possible, since every hashed structure carries its version, and old leaves keep verifying.
+Removing it is not. Choosing A now costs an option we can still exercise; choosing C now spends
+32 bytes per leaf and a verifier step forever, before anyone has written anything.
+
+### What this commits us to
+
+- Ed25519 stays. Secure Enclave stays unavailable, and the key lives in Keychain or an encrypted
+  file — gated by biometrics, encrypted at rest, extractable by design because it must move.
+- Multi-device is an explicit act by the creator, not background sync.
+- Rotation semantics must still be designed (P1). Under A, rotation means "a new key takes over
+  from here," which is a chain-visible event rather than a set membership change.
+
+### What would change the recommendation
+
+- Hardware binding turning out to matter more to real users than recovery.
+- Key transport proving unusably awkward in practice — the honest test is whether *you* find it
+  tolerable moving a key between your Mac and your phone.
+- Multi-writer arriving sooner than expected, since C generalises to it and A does not.
+
+---
+
+## Open
+
+- **Rotation semantics under A.** What a rotation leaf looks like, what a verifier checks, and
+  whether `recovery_key` can itself rotate. P1, and now the last undefined thing in the format.
+- **Key transport mechanics.** QR, encrypted file, something else — a UX question, not a format
+  one, which is the point of choosing A.
+- **Whether `recovery_key` is still right under A.** If rotation is a chain-visible event signed
+  by the outgoing key, a lost key cannot sign the rotation — which is exactly the case
+  `recovery_key` exists for. Its semantics must handle "the key that should authorise this
+  transition is the one that is gone."

--- a/docs/design/registry-and-provenance.md
+++ b/docs/design/registry-and-provenance.md
@@ -1,0 +1,179 @@
+# Registry and Provenance — How the Two Systems Relate
+
+**Status:** design, pre-implementation · **Companion to:** [`provenance-data-model.md`](./provenance-data-model.md), [`key-authorization.md`](./key-authorization.md)
+
+DAON will have two things that both look like "proving a work is yours." They are different
+systems with different trust models, and conflating them would quietly weaken the stronger one.
+
+---
+
+## What exists today
+
+Registration through the web app and API:
+
+```js
+creator: this.address        // api-server/src/blockchain.ts — the API wallet
+```
+
+```sql
+user_id       INTEGER REFERENCES users(id) ON DELETE SET NULL
+content_hash  VARCHAR(64) UNIQUE NOT NULL
+```
+
+Three consequences, none of them criticisms — this is a reasonable design for what it does:
+
+- **On-chain, the signer is DAON.** Every registration is signed by the API wallet. The chain
+  records that *DAON registered this hash at this time*, not that a particular person did.
+- **Ownership lives only in Postgres**, in a nullable column that is set to `NULL` when a user is
+  deleted. It is an application fact, not a cryptographic one.
+- **The content hash is already the primary identifier**, unique and publicly queryable at
+  `GET /api/v1/verify/:hash`.
+
+The registry answers a real question well: *did this exact content exist in DAON's registry by
+this date.* Its trust anchor is DAON.
+
+## What provenance adds
+
+The creator's own key signs each revision; the chain is witnessed against Bitcoin. Its trust
+anchor is Bitcoin, deliberately, so DAON is never the anchor for its own claims.
+
+| | Registry | Provenance |
+| --- | --- | --- |
+| Who signs | the API wallet | the creator's key |
+| Where the user is | a database row | nowhere on our servers |
+| Trust anchor | DAON | Bitcoin |
+| Proves | this hash was registered by date T | this chain of revisions existed, under one key |
+| Survives DAON disappearing | no | yes |
+
+Neither replaces the other. The registry is a service; provenance is evidence.
+
+---
+
+## The link is the content hash, not an account
+
+The obvious instinct is to require sign-in: the user authenticates, and DAON records that their
+account owns both the registration and the provenance chain.
+
+**Don't.** The linkage already exists, publicly and verifiably:
+
+```
+registry:    content_hash X, registered at T
+provenance:  genesis leaf whose content_commit derives from the same bytes
+```
+
+Anyone holding the content can check both sides themselves. No account, no server assertion, no
+authority in the middle — which makes it *stronger* than a sign-in-based link, because a third
+party can confirm it without trusting us.
+
+### Why an account link would be worse
+
+**Accounts are recoverable; keys are not.** Every service must offer 2FA recovery, and it is on
+DAON's own roadmap. If an account is authoritative for "this key is that person's," then account
+recovery becomes an attack path on provenance: take over the account, attest a different key. The
+account protects a login; the chain proves fourteen months of revisions. Binding the stronger
+claim to the weaker one lets the weaker one set the ceiling, and 2FA does not fix it because the
+hole is in recovery rather than authentication.
+
+**It rebuilds the aggregation surface.** A key→account map lets DAON answer *"what has this
+person registered."* That is the surface ruled out for collections, for the same reasons:
+subpoenable, breachable, pressure-able, and it makes *"there is no endpoint to query a creator's
+profile"* false.
+
+**For existing records it does not even work.** Ownership is a nullable column that has already
+been lost once. Sign-in would retrieve a database row, not a fact.
+
+---
+
+## "Someone else could claim my registered hash"
+
+They can. Anyone holding the content can start a chain about it. This is not a flaw to be closed;
+it is the model working.
+
+**Chains compete on evidence, not authority.** A claimant's chain starts today, with today's
+witness. Yours reaches back months, witnessed at every step against blocks nobody controls.
+Earlier witnessed history wins, and no registry adjudicates between them.
+
+Closing this "hole" would mean appointing DAON to decide whose claim is real — which is the
+gatekeeping role the project exists to refuse. The right answer to a competing claim is better
+evidence, not a higher authority.
+
+---
+
+## What sign-in is actually for
+
+**Convenience, never protocol.** Legitimate uses:
+
+- the dashboard, settings, existing registry flows
+- showing a creator which registrations correspond to content they hold
+
+That second one is worth being precise about. Matching a local file against the registry is a
+**local computation**: hash the file, query the public endpoint. Sign-in is not needed to *do* it,
+only to conveniently list what a user has already registered.
+
+**Requirements:**
+
+1. Creating a key and starting a chain **must not require an account.** The moment it does, the
+   account is load-bearing again.
+2. The agent **must never send content or keys to the API.** Its only egress remains
+   OpenTimestamps.
+3. If a creator wants their key publicly associated with them, that is an affirmative act they
+   publish — optionally counter-attested by their account, where 2FA genuinely helps make the
+   attestation credible. It is not a registry DAON maintains and answers queries about.
+
+---
+
+## Adding provenance to an existing registration
+
+The flow, with no account required:
+
+1. Creator has content that was registered previously, and the file.
+2. The agent starts an entity whose genesis commits to that content.
+3. Subsequent revisions extend the chain normally.
+4. The registry record is unchanged. It remains what it always was: a timestamped statement that
+   this hash was registered by date T.
+
+The two coexist without either being subordinate. A relying party sees:
+
+> The registry says this hash existed by 2026-03-14. The creator's chain shows revisions from
+> 2025-11 through 2026-08, witnessed independently, under a single key.
+
+Those are separate claims from separate anchors, and both can be checked. **The registration
+becomes one fact among several rather than the root of the claim** — which is a strengthening,
+since the registry's anchor is us and the chain's is not.
+
+### For the records whose ownership was lost
+
+The reindexed records have no `user_id`. Under an account-linked design that would be
+unrecoverable. Under content-hash linkage it does not matter: a creator who still holds the
+content can start a chain about it and needs nothing from the database.
+
+The lost column stops being a problem to solve.
+
+---
+
+## The `revision_history` fossil
+
+`content_record.revision_history` exists on-chain as `repeated string` — a bare list of hashes,
+with no Merkle structure, no witnesses and no signatures. It is a remnant of an earlier
+chain-based versioning idea that the provenance data model supersedes.
+
+It should be **left alone, unused**. Writing to it would create a second, weaker version history
+that says something different from the real one, and two histories that can disagree is worse
+than one.
+
+Removing it is a chain migration for no benefit. It stays as dead weight until there is another
+reason to touch the module.
+
+---
+
+## Open
+
+- **Does the app surface provenance at all in the MVP?** The editor needs it. Whether
+  daon.network displays chain state is a product question, and displaying it invites exactly the
+  comparisons `editor-integration-spec.md` §6 forbids.
+- **Discovery.** With no key→account registry, a reader who wants to check a claim must be given
+  the disclosure by the creator. That is the intended default and it is also a UX problem nobody
+  has designed.
+- **Whether the registry should record that a hash has a chain.** A boolean would be harmless
+  and useful; it is also the first step toward a queryable profile, so it needs deciding
+  deliberately rather than drifting into existence.


### PR DESCRIPTION
**Blocking question for the agent.** Not implemented — a proposal for your decision.

## How this surfaced

Asking whether Secure Enclave was usable. It isn't, as specified:

```
author_key       32 bytes, no algorithm identifier anywhere in the leaf
P-256 pubkey     33 bytes compressed
```

The field physically cannot hold one. Secure Enclave does **P-256 only** — CryptoKit's `Curve25519.Signing.PrivateKey` is a *software* key; only `SecureEnclave.P256.Signing.PrivateKey` is hardware-backed.

Chasing that exposed the bigger problem: SEP keys are **non-extractable and device-bound**, so using one means more than one key per entity — and the format has exactly one `author_key` and no mechanism authorising another.

## Three pressures, one question

| | |
| --- | --- |
| **Multi-device** | drafts on a laptop, fixes a line on a phone |
| **Key loss** | `recovery_key` is reserved but its semantics are undefined |
| **Hardware keys** | device-bound by construction |

All of them ask *which keys may extend this chain*. Answering them separately produces two mechanisms that then have to agree.

## A scoping error of mine

The specs listed multi-device as out of scope under "single-writer." That conflated:

- **single-writer** — no concurrent authors. Genuinely deferrable.
- **single-device** — never described real writing.

A solo author moving between their own devices is the normal case. It got scoped out by accident, and the integration spec is corrected here.

## What a witnessed head already settles

Worth stating, because it removes the attack people reach for first.

A verifier trusting a witnessed head trusts that every leaf beneath it existed when it was witnessed. **An attacker cannot retroactively insert an authorization leaf** — that needs a SHA-256 collision or a rewrite of Bitcoin.

So the question is never "could this authorization have been forged into the past." Only: among leaves under a head I already trust, was this signature made by a key allowed to sign.

## The options

| | Verifier | Format | Secure Enclave | Multi-device | Cross-platform |
| --- | --- | --- | --- | --- | --- |
| **A** one key, moved deliberately | **4 steps** | unchanged | no | manual | complete |
| **B** one key, platform-synced | 4 steps | unchanged | no | automatic | Apple only |
| **C** `key_set_root` per leaf | 5 steps | +32 B/leaf | **yes** | native | complete |
| **D** device-bound entities | 4 steps | unchanged | yes | fragmented | complete |

C's fifth step is a Merkle membership proof against a root already in the leaf — local, O(log keys), reusing the tree code that exists. It's cheap. It's still a fifth step.

## Recommendation: A now, C's shape kept possible

Priority order, not a claim that C is worse:

**The verifier is what's being protected.** A is the only option leaving it at four steps.

**Recovery outranks theft-resistance — already decided.** `recovery_key` went in because a frozen chain is a real harm. Secure Enclave maximises theft-resistance by making loss *permanent*, which is the exact failure mode we designed against. Hardware binding fits this project worse than it first appears.

**A works everywhere.** SEP is Apple, StrongBox is inconsistent, Linux gets a software key regardless. A permanent format change for a partial-platform benefit is a poor trade.

**A is reversible; C is not.** Every hashed structure carries its version, so `key_set_root` can be added later with old leaves still verifying. It cannot be removed once shipped.

### What A commits us to

- **Ed25519 stays; Secure Enclave stays unavailable.** The key lives in Keychain or an encrypted file — biometric-gated, encrypted at rest, extractable **by design**, because it has to move.
- **Multi-device is an explicit act**, not background sync.
- Rotation becomes "a new key takes over from here" — a chain-visible event.

### What would change it

- Hardware binding mattering more to real users than recovery
- Key transport proving unusably awkward — **the honest test is whether *you* find it tolerable moving a key between your Mac and your phone**
- Multi-writer arriving sooner than expected, since C generalises to it and A doesn't

## Still open after this

`recovery_key`'s semantics under A, and there's a wrinkle: if rotation is signed by the outgoing key, a *lost* key cannot sign its own rotation — which is precisely the case `recovery_key` exists for. That has to be designed as "the key that should authorise this transition is the one that's gone."

That's now the last undefined thing in the format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)