### PR TITLE
feat(provenance): the four-step verifier, plus CI that actually tests it

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,10 @@ jobs:
       sdk_python: ${{ steps.filter.outputs.sdk_python }}
       sdk_ruby:   ${{ steps.filter.outputs.sdk_ruby }}
       sdk_php:    ${{ steps.filter.outputs.sdk_php }}
+      provenance: ${{ steps.filter.outputs.provenance }}
+      wordpress:  ${{ steps.filter.outputs.wordpress }}
+      ccc:        ${{ steps.filter.outputs.ccc }}
+      verifysvc:  ${{ steps.filter.outputs.verifysvc }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -41,6 +45,18 @@ jobs:
               - 'sdks/ruby/**'
             sdk_php:
               - 'sdks/php/**'
+            # The Rust crates and the Python reference encoder are one unit: a
+            # change to either can fork the wire format, so both trigger the
+            # cross-implementation check.
+            provenance:
+              - 'provenance/**'
+              - 'scripts/provenance/**'
+            wordpress:
+              - 'wordpress-plugin/**'
+            ccc:
+              - 'creative-commons-chain/**'
+            verifysvc:
+              - 'verification-service/**'
 
   # ── API Server ────────────────────────────────────────────────────────────
 
@@ -212,6 +228,122 @@ jobs:
 
   # ── SDK Tests ─────────────────────────────────────────────────────────────
 
+  # ── Provenance ────────────────────────────────────────────────────────────
+
+  provenance:
+    name: Provenance (Rust)
+    needs: changes
+    if: needs.changes.outputs.provenance == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: provenance
+    steps:
+      - uses: actions/checkout@v4
+      # No toolchain version here on purpose: provenance/rust-toolchain.toml is
+      # the single source of truth, so CI cannot drift from a developer machine
+      # the way go.mod and the Dockerfile did.
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Format
+        run: cargo fmt --all --check
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Tests
+        run: cargo test --all-features
+      - name: Tests without optional features
+        # Steps 1-3 of the verifier must work without signature support, and a
+        # build lacking it must fail closed rather than accept any signature.
+        run: cargo test -p daon-provenance-verify --no-default-features --features std
+      - name: Build for wasm32
+        # The verifier's value depends on a skeptic being able to run it in a
+        # browser without trusting a binary we shipped.
+        run: cargo build --target wasm32-unknown-unknown --release
+
+      - name: Reference encoder self-check
+        working-directory: .
+        run: python3 scripts/provenance/wire_ref.py
+
+      - name: Cross-implementation check
+        working-directory: .
+        # The decisive test. Each side's unit tests assert hardcoded values, so
+        # both would keep passing if one drifted -- an implementation checking
+        # itself proves nothing about a wire format. This diffs the two.
+        run: |
+          python3 scripts/provenance/emit_vectors.py > /tmp/py.txt
+          (cd provenance && cargo run -q -p daon-provenance-core --example vectors) > /tmp/rs.txt
+          if ! diff -u /tmp/py.txt /tmp/rs.txt; then
+            echo "::error::Python reference and Rust crate disagree on the wire format."
+            echo "::error::Every historic proof depends on these bytes. This is never a formatting nit."
+            exit 1
+          fi
+          echo "$(wc -l < /tmp/py.txt) vectors agree byte-for-byte"
+
+  # ── WordPress plugin ──────────────────────────────────────────────────────
+
+  wordpress:
+    name: WordPress Plugin Tests
+    needs: changes
+    if: needs.changes.outputs.wordpress == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: wordpress-plugin/daon-creator-protection
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+      - name: Lint
+        run: find . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l
+      - name: PHPUnit
+        # The bootstrap stubs WordPress, so no WP install is required.
+        run: composer test
+
+  # ── creative-commons-chain ────────────────────────────────────────────────
+
+  ccc-build:
+    name: creative-commons-chain Build
+    needs: changes
+    if: needs.changes.outputs.ccc == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: creative-commons-chain/go.mod
+      - name: Build
+        env:
+          GOTOOLCHAIN: local
+        run: cd creative-commons-chain && go build ./...
+
+  # ── verification-service ──────────────────────────────────────────────────
+
+  verification-service:
+    name: Verification Service Build
+    needs: changes
+    if: needs.changes.outputs.verifysvc == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: verification-service
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci || npm install
+      - run: npm run build
+
   test-go:
     name: Go SDK Tests
     needs: changes
@@ -297,7 +429,12 @@ jobs:
       - test
       - build-test
       - blockchain-build-test
+      - blockchain-docker-build
       - frontend-test
+      - provenance
+      - wordpress
+      - ccc-build
+      - verification-service
       - test-go
       - test-node-sdk
       - test-python
@@ -311,7 +448,12 @@ jobs:
           R_TEST:        ${{ needs.test.result }}
           R_BUILD:       ${{ needs.build-test.result }}
           R_BLOCKCHAIN:  ${{ needs.blockchain-build-test.result }}
+          R_BCDOCKER:    ${{ needs.blockchain-docker-build.result }}
           R_FRONTEND:    ${{ needs.frontend-test.result }}
+          R_PROVENANCE:  ${{ needs.provenance.result }}
+          R_WORDPRESS:   ${{ needs.wordpress.result }}
+          R_CCC:         ${{ needs.ccc-build.result }}
+          R_VERIFYSVC:   ${{ needs.verification-service.result }}
           R_GO:          ${{ needs.test-go.result }}
           R_NODE:        ${{ needs.test-node-sdk.result }}
           R_PYTHON:      ${{ needs.test-python.result }}
@@ -337,8 +479,19 @@ jobs:
 
           echo ""                              >> "$GITHUB_STEP_SUMMARY"
           echo "### Core"                      >> "$GITHUB_STEP_SUMMARY"
-          render "Blockchain Build" "$R_BLOCKCHAIN"
-          render "Frontend & E2E"   "$R_FRONTEND"
+          render "Blockchain Build"        "$R_BLOCKCHAIN"
+          render "Blockchain Docker Build" "$R_BCDOCKER"
+          render "Frontend & E2E"          "$R_FRONTEND"
+          render "creative-commons-chain"  "$R_CCC"
+          render "Verification Service"    "$R_VERIFYSVC"
+
+          echo ""                              >> "$GITHUB_STEP_SUMMARY"
+          echo "### Provenance"                >> "$GITHUB_STEP_SUMMARY"
+          render "Rust + cross-impl check" "$R_PROVENANCE"
+
+          echo ""                              >> "$GITHUB_STEP_SUMMARY"
+          echo "### Integrations"              >> "$GITHUB_STEP_SUMMARY"
+          render "WordPress Plugin" "$R_WORDPRESS"
 
           echo ""                              >> "$GITHUB_STEP_SUMMARY"
           echo "### SDKs"                      >> "$GITHUB_STEP_SUMMARY"
@@ -350,8 +503,9 @@ jobs:
 
           # Fail the summary job if any non-skipped job failed
           all_ok=true
-          for result in "$R_SECURITY" "$R_TEST" "$R_BUILD" "$R_BLOCKCHAIN" \
-                        "$R_FRONTEND" "$R_GO" "$R_NODE" "$R_PYTHON" "$R_RUBY" "$R_PHP"; do
+          for result in "$R_SECURITY" "$R_TEST" "$R_BUILD" "$R_BLOCKCHAIN" "$R_BCDOCKER" \
+                        "$R_FRONTEND" "$R_PROVENANCE" "$R_WORDPRESS" "$R_CCC" "$R_VERIFYSVC" \
+                        "$R_GO" "$R_NODE" "$R_PYTHON" "$R_RUBY" "$R_PHP"; do
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               all_ok=false
             fi

--- a/provenance/Cargo.lock
+++ b/provenance/Cargo.lock
@@ -37,10 +37,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "daon-provenance-core"
 version = "0.0.0"
 dependencies = [
  "sha2",
+]
+
+[[package]]
+name = "daon-provenance-verify"
+version = "0.0.0"
+dependencies = [
+ "daon-provenance-core",
+ "ed25519-dalek",
 ]
 
 [[package]]
@@ -52,6 +86,33 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "generic-array"
@@ -70,6 +131,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,10 +175,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "version_check"

--- a/provenance/Cargo.toml
+++ b/provenance/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["core"]
+members = ["core", "verify"]
 
 [workspace.package]
 edition = "2021"
@@ -10,3 +10,5 @@ repository = "https://github.com/daon-network/daon"
 
 [workspace.dependencies]
 sha2 = { version = "0.10", default-features = false }
+ed25519-dalek = { version = "2", default-features = false }
+daon-provenance-core = { path = "core", default-features = false }

--- a/provenance/core/examples/vectors.rs
+++ b/provenance/core/examples/vectors.rs
@@ -1,0 +1,82 @@
+//! Emits the wire-format vectors in a stable `name<TAB>hex` form.
+//!
+//! Exists so CI can diff this against `scripts/provenance/wire_ref.py`. The unit
+//! tests assert hardcoded expectations, which means they would keep passing if
+//! the Python reference drifted — each implementation checking itself proves
+//! nothing about the format. This is the check that actually catches a fork.
+
+use daon_provenance_core::*;
+
+fn hex(b: &[u8]) -> String {
+    b.iter().map(|x| format!("{x:02x}")).collect()
+}
+
+fn main() {
+    let o1 = Observation {
+        tool_id: b"ref/1.0".to_vec(),
+        ingress: Ingress::Paste,
+        added: 214,
+        removed: 12,
+        duration_ms: 45200,
+        op_count: 87,
+    };
+    let o2 = Observation {
+        tool_id: b"ref/1.0".to_vec(),
+        ingress: Ingress::KeystrokeStream,
+        added: 1180,
+        removed: 96,
+        duration_ms: 51000,
+        op_count: 1431,
+    };
+    let mc2 = meta_commit(&[o1.clone(), o2.clone()]).unwrap();
+    let cc = content_commit(b"the quick brown fox");
+
+    let leaf = RevisionLeaf {
+        seq: 0,
+        parent_head: [0u8; 32],
+        content_commit: cc,
+        meta_commit: mc2,
+        beacon: Beacon {
+            chain: BeaconChain::Bitcoin,
+            height: 880_000,
+            block_hash: {
+                let mut b = [0u8; 32];
+                b[28..].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+                b
+            },
+        },
+        author_key: [0x11u8; 32],
+        recovery_key: [0x22u8; 32],
+        local_time_ms: 1_754_000_000_000,
+    };
+
+    let leaves: Vec<Hash> = (0u8..5).map(|i| merkle_leaf(&[i])).collect();
+    let root = merkle_root(&leaves);
+    let proof = inclusion_proof(&leaves, 3);
+
+    let seg_doc: Vec<u8> = [1u8, 2, 3]
+        .iter()
+        .flat_map(|b| core::iter::repeat_n(*b, 1024))
+        .collect();
+
+    println!("observation0\t{}", hex(&o1.encode().unwrap()));
+    println!("obs_leaf0\t{}", hex(&o1.leaf_hash().unwrap()));
+    println!("obs_leaf1\t{}", hex(&o2.leaf_hash().unwrap()));
+    println!("meta_commit1\t{}", hex(&meta_commit(&[o1]).unwrap()));
+    println!("meta_commit2\t{}", hex(&mc2));
+    println!("content_commit\t{}", hex(&cc));
+    println!("seg_root\t{}", hex(&content_commit(&seg_doc)));
+    println!("leaf_body\t{}", hex(&leaf.encode()));
+    println!("leaf_id\t{}", hex(&leaf.leaf_id()));
+    for (i, l) in leaves.iter().enumerate() {
+        println!("leaf{i}\t{}", hex(l));
+    }
+    println!("merkle_root\t{}", hex(&root));
+    for (i, (side, sib)) in proof.iter().enumerate() {
+        let s = match side {
+            Side::Left => "L",
+            Side::Right => "R",
+        };
+        println!("proof{i}\t{s}:{}", hex(sib));
+    }
+}

--- a/provenance/core/src/lib.rs
+++ b/provenance/core/src/lib.rs
@@ -268,6 +268,15 @@ impl RevisionLeaf {
     }
 }
 
+/// Hash bytes under a domain separation tag: `SHA256(tag || bytes)`.
+///
+/// Exposed so downstream crates can recompute a tagged hash — a content segment,
+/// say — without taking a direct dependency on a hash implementation. Keeping the
+/// verifier's dependency surface small is a design goal, not an accident.
+pub fn hash_tagged(tag: u8, bytes: &[u8]) -> Hash {
+    sha256(&[&[tag], bytes])
+}
+
 /// Hash arbitrary bytes as a Merkle leaf: `SHA256(0x00 || bytes)`.
 ///
 /// Callers building a log of revisions want [`RevisionLeaf::leaf_id`]; this is

--- a/provenance/verify/Cargo.toml
+++ b/provenance/verify/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "daon-provenance-verify"
+version = "0.0.0"          # not published; the wire format is not frozen yet
+description = "The four-step minimum verifier for DAON provenance claims"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+daon-provenance-core.workspace = true
+ed25519-dalek = { workspace = true, optional = true }
+
+[features]
+default = ["std", "signatures"]
+std = ["daon-provenance-core/std"]
+# Step 4 only. Steps 1-3 must keep working without it, so a verifier that does
+# not care about authorship can be built smaller.
+signatures = ["dep:ed25519-dalek"]

--- a/provenance/verify/src/lib.rs
+++ b/provenance/verify/src/lib.rs
@@ -1,0 +1,186 @@
+//! The four-step minimum verifier for DAON provenance claims.
+//!
+//! From `docs/design/provenance-data-model.md`, given `(leaf, inclusion_proof,
+//! witness_receipt)`:
+//!
+//! 1. Recompute the leaf hash from disclosed fields.
+//! 2. Walk `inclusion_proof` from leaf → `witnessed_head` — O(log n).
+//! 3. Verify the witness attestation resolves to a Bitcoin block ≥ `witness_time`.
+//! 4. *(optional)* Verify the author signature on the leaf.
+//!
+//! > One trusted anchor. One log-depth walk. Constant in leaf count. Multi-witness,
+//! > consistency chains, selective-disclosure ZK and fork traversal are **later
+//! > features, never part of this path.**
+//!
+//! That instruction is why this crate exists separately from anything that stores,
+//! coalesces or witnesses. Keeping the verifier small is a design goal with teeth:
+//! it is the thing a skeptic runs, and every dependency it grows is something they
+//! have to trust or audit.
+//!
+//! # What this crate does not decide
+//!
+//! Step 3 takes an already-established [`WitnessAttestation`]. Parsing an
+//! OpenTimestamps proof and resolving it against Bitcoin headers is a distinct
+//! trust anchor with its own failure modes, and folding it in here would mean a
+//! verifier that cannot run without a chain source. Separating them lets a
+//! relying party choose how they establish Bitcoin state — their own node, a
+//! header chain they already trust, or an OTS client — without this crate having
+//! an opinion.
+//!
+//! **A caller that fabricates an attestation gets a meaningless answer.** That is
+//! stated rather than defended against, because it cannot be defended against
+//! here: the verifier's job is to check a claim against an anchor, not to decide
+//! what anchors are real.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+extern crate alloc;
+use daon_provenance_core::{hash_tagged, tag, verify_inclusion, Hash, ProofStep, RevisionLeaf};
+
+/// An established statement that a head existed by a given time.
+///
+/// Existence and ordering only. A witness attests that these bytes existed by
+/// this time — never anything about who made them, how, or whether the content
+/// is any good.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WitnessAttestation {
+    /// The head this attestation covers.
+    pub witnessed_head: Hash,
+    /// Unix milliseconds. The upper time bound for every leaf beneath the head.
+    pub witness_time_ms: i64,
+}
+
+/// Why a claim did not verify.
+///
+/// Each variant names the step that failed, so a caller can report something
+/// more useful than "invalid".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Failure {
+    /// Step 2: the inclusion proof does not fold to the witnessed head.
+    NotInWitnessedHead,
+    /// Step 3: the attestation covers a different head than the proof reaches.
+    AttestationHeadMismatch,
+    /// Step 3: the leaf claims a beacon later than the witness time, so the
+    /// sandwich is inverted and no honest leaf could sit here.
+    TimeBoundsInverted,
+    /// Step 4: the signature does not verify under the leaf's `author_key`.
+    #[cfg(feature = "signatures")]
+    BadSignature,
+    /// Step 4 was requested but the key is not a valid Ed25519 point.
+    #[cfg(feature = "signatures")]
+    MalformedAuthorKey,
+    /// Step 4 was requested of a verifier built without signature support.
+    #[cfg(not(feature = "signatures"))]
+    SignaturesUnsupported,
+}
+
+/// What a successful verification establishes — and, as importantly, what it does not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Verified {
+    /// This leaf existed no later than here.
+    pub existed_by_ms: i64,
+    /// Whether step 4 ran. `false` means existence is proven but authorship is not
+    /// — a distinction a caller must not flatten.
+    pub author_signature_checked: bool,
+}
+
+/// A claim to be checked.
+pub struct Claim<'a> {
+    /// The leaf, with whatever fields the holder disclosed.
+    pub leaf: &'a RevisionLeaf,
+    /// Sibling hashes from the leaf to the witnessed head.
+    pub proof: &'a [ProofStep],
+    /// The head the proof should reach.
+    pub head: Hash,
+    /// An established witness statement about that head.
+    pub attestation: WitnessAttestation,
+    /// Ed25519 signature over the leaf id. `None` skips step 4.
+    pub signature: Option<&'a [u8; 64]>,
+}
+
+/// Run the four steps.
+///
+/// Returns what was established, or the first step that failed. Steps run in
+/// order and stop at the first failure, so the error names the earliest thing
+/// wrong rather than an arbitrary one.
+pub fn verify(claim: &Claim<'_>) -> Result<Verified, Failure> {
+    // Step 1 — recompute the leaf hash from disclosed fields.
+    let leaf_id = claim.leaf.leaf_id();
+
+    // Step 2 — walk the proof to the witnessed head.
+    if !verify_inclusion(&leaf_id, claim.proof, &claim.head) {
+        return Err(Failure::NotInWitnessedHead);
+    }
+
+    // Step 3 — the attestation must be about the head we actually reached.
+    if claim.attestation.witnessed_head != claim.head {
+        return Err(Failure::AttestationHeadMismatch);
+    }
+
+    // The beacon's lower bound is checked by `beacon_lower_bound`, not here:
+    // resolving a block height to a timestamp needs a chain source, and the
+    // minimum verifier does not get to require one.
+    let existed_by_ms = claim.attestation.witness_time_ms;
+
+    // Step 4 — optional.
+    let author_signature_checked = match claim.signature {
+        None => false,
+        Some(sig) => {
+            check_signature(&claim.leaf.author_key, &leaf_id, sig)?;
+            true
+        }
+    };
+
+    Ok(Verified {
+        existed_by_ms,
+        author_signature_checked,
+    })
+}
+
+/// Check the beacon sandwich once a caller has resolved the beacon block to a time.
+///
+/// Separate from [`verify`] because resolving a block height to a timestamp needs
+/// a chain source, and the minimum verifier does not get to require one. A caller
+/// that can resolve it should call this too; one that cannot still gets steps 1, 2
+/// and 4.
+pub fn beacon_lower_bound(
+    beacon_time_ms: i64,
+    attestation: &WitnessAttestation,
+) -> Result<(), Failure> {
+    if beacon_time_ms > attestation.witness_time_ms {
+        return Err(Failure::TimeBoundsInverted);
+    }
+    Ok(())
+}
+
+#[cfg(feature = "signatures")]
+fn check_signature(author_key: &Hash, leaf_id: &Hash, sig: &[u8; 64]) -> Result<(), Failure> {
+    use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+    let key = VerifyingKey::from_bytes(author_key).map_err(|_| Failure::MalformedAuthorKey)?;
+    key.verify(leaf_id, &Signature::from_bytes(sig))
+        .map_err(|_| Failure::BadSignature)
+}
+
+#[cfg(not(feature = "signatures"))]
+fn check_signature(_: &Hash, _: &Hash, _: &[u8; 64]) -> Result<(), Failure> {
+    // Fail closed. Returning Ok here would report author_signature_checked: true
+    // having verified nothing at all -- a build without the feature would silently
+    // accept any signature. A caller asking for step 4 in a verifier that cannot
+    // perform step 4 must be told so.
+    Err(Failure::SignaturesUnsupported)
+}
+
+/// Prove one content segment against a leaf's `content_commit`.
+///
+/// This is a **creator-initiated** disclosure. DAON issues no endpoint taking a
+/// segment index and no certificate rendering one; a holder produces this from
+/// content only they possess and hands it to whoever they choose.
+///
+/// Callers must not treat a missing segment proof as meaningful. Declining to
+/// disclose is the default, not an admission.
+pub fn verify_segment(segment_bytes: &[u8], proof: &[ProofStep], content_commit: &Hash) -> bool {
+    let leaf = hash_tagged(tag::CONTENT, segment_bytes);
+    verify_inclusion(&leaf, proof, content_commit)
+}

--- a/provenance/verify/tests/verifier.rs
+++ b/provenance/verify/tests/verifier.rs
@@ -1,0 +1,239 @@
+//! Tests for the four-step minimum verifier.
+//!
+//! Most of these are negative. A verifier that accepts good claims is easy; the
+//! whole value is in what it refuses, so every step gets a test that breaks it.
+
+use daon_provenance_core::*;
+use daon_provenance_verify::*;
+
+fn leaf_at(seq: u64, content: &[u8]) -> RevisionLeaf {
+    RevisionLeaf {
+        seq,
+        parent_head: [0u8; 32],
+        content_commit: content_commit(content),
+        meta_commit: meta_commit(&[Observation {
+            tool_id: b"test/1.0".to_vec(),
+            ingress: Ingress::KeystrokeStream,
+            added: 100,
+            removed: 0,
+            duration_ms: 5000,
+            op_count: 40,
+        }])
+        .unwrap(),
+        beacon: Beacon {
+            chain: BeaconChain::Bitcoin,
+            height: 880_000,
+            block_hash: [0xab; 32],
+        },
+        author_key: [0x11u8; 32],
+        recovery_key: [0x22u8; 32],
+        local_time_ms: 1_754_000_000_000,
+    }
+}
+
+/// A small log with a real head and proofs, as an agent would produce.
+fn log_of(n: u64) -> (Vec<RevisionLeaf>, Vec<Hash>, Hash) {
+    let leaves: Vec<RevisionLeaf> = (0..n).map(|i| leaf_at(i, b"some content")).collect();
+    let ids: Vec<Hash> = leaves.iter().map(|l| l.leaf_id()).collect();
+    let head = merkle_root(&ids);
+    (leaves, ids, head)
+}
+
+#[test]
+fn a_good_claim_verifies() {
+    let (leaves, ids, head) = log_of(5);
+    let proof = inclusion_proof(&ids, 3);
+    let out = verify(&Claim {
+        leaf: &leaves[3],
+        proof: &proof,
+        head,
+        attestation: WitnessAttestation {
+            witnessed_head: head,
+            witness_time_ms: 1_754_000_900_000,
+        },
+        signature: None,
+    })
+    .expect("should verify");
+
+    assert_eq!(out.existed_by_ms, 1_754_000_900_000);
+    assert!(
+        !out.author_signature_checked,
+        "no signature supplied, so authorship is not established"
+    );
+}
+
+#[test]
+fn step2_a_leaf_not_under_the_head_is_refused() {
+    let (leaves, ids, head) = log_of(5);
+    let proof = inclusion_proof(&ids, 3);
+    // Same proof, different leaf.
+    let err = verify(&Claim {
+        leaf: &leaves[2],
+        proof: &proof,
+        head,
+        attestation: WitnessAttestation {
+            witnessed_head: head,
+            witness_time_ms: 1_754_000_900_000,
+        },
+        signature: None,
+    })
+    .unwrap_err();
+    assert_eq!(err, Failure::NotInWitnessedHead);
+}
+
+#[test]
+fn step2_a_tampered_leaf_is_refused() {
+    let (leaves, ids, head) = log_of(5);
+    let proof = inclusion_proof(&ids, 1);
+    let mut tampered = leaves[1].clone();
+    tampered.local_time_ms += 1; // one field, one millisecond
+
+    let err = verify(&Claim {
+        leaf: &tampered,
+        proof: &proof,
+        head,
+        attestation: WitnessAttestation {
+            witnessed_head: head,
+            witness_time_ms: 1_754_000_900_000,
+        },
+        signature: None,
+    })
+    .unwrap_err();
+    assert_eq!(
+        err,
+        Failure::NotInWitnessedHead,
+        "changing any hashed field must break inclusion"
+    );
+}
+
+#[test]
+fn step3_an_attestation_about_another_head_is_refused() {
+    let (leaves, ids, head) = log_of(5);
+    let proof = inclusion_proof(&ids, 0);
+    let err = verify(&Claim {
+        leaf: &leaves[0],
+        proof: &proof,
+        head,
+        attestation: WitnessAttestation {
+            witnessed_head: [0xff; 32], // a head this proof never reaches
+            witness_time_ms: 1_754_000_900_000,
+        },
+        signature: None,
+    })
+    .unwrap_err();
+    assert_eq!(err, Failure::AttestationHeadMismatch);
+}
+
+#[test]
+fn beacon_sandwich_rejects_inverted_bounds() {
+    let att = WitnessAttestation {
+        witnessed_head: [0u8; 32],
+        witness_time_ms: 1_000,
+    };
+    assert!(
+        beacon_lower_bound(999, &att).is_ok(),
+        "beacon before witness is fine"
+    );
+    assert!(beacon_lower_bound(1_000, &att).is_ok(), "equal is fine");
+    assert_eq!(
+        beacon_lower_bound(1_001, &att).unwrap_err(),
+        Failure::TimeBoundsInverted,
+        "a leaf cannot predate a beacon it names while being witnessed earlier"
+    );
+}
+
+#[test]
+fn segment_disclosure_verifies_and_rejects_tampering() {
+    // Three distinct 1 KiB segments. Distinct matters: identical segments would
+    // make a substituted-segment proof appear to verify, which is how a fixture
+    // hides a real bug.
+    let doc: Vec<u8> = [1u8, 2, 3]
+        .iter()
+        .flat_map(|b| core::iter::repeat_n(*b, 1024))
+        .collect();
+    let commit = content_commit(&doc);
+    let segs = segments(&doc);
+    let seg_leaves: Vec<Hash> = segs.iter().map(|s| hash_tagged(tag::CONTENT, s)).collect();
+    let proof = inclusion_proof(&seg_leaves, 1);
+
+    assert!(verify_segment(segs[1], &proof, &commit));
+    assert!(
+        !verify_segment(segs[2], &proof, &commit),
+        "a different segment under this proof must not verify"
+    );
+    assert!(
+        !verify_segment(&[0u8; 1024], &proof, &commit),
+        "tampered content must not verify"
+    );
+}
+
+#[cfg(feature = "signatures")]
+mod signatures {
+    use super::*;
+
+    #[test]
+    fn a_garbage_signature_is_refused() {
+        let (leaves, ids, head) = log_of(3);
+        let proof = inclusion_proof(&ids, 0);
+        let sig = [0u8; 64];
+        let err = verify(&Claim {
+            leaf: &leaves[0],
+            proof: &proof,
+            head,
+            attestation: WitnessAttestation {
+                witnessed_head: head,
+                witness_time_ms: 1_754_000_900_000,
+            },
+            signature: Some(&sig),
+        })
+        .unwrap_err();
+        // author_key here is 0x11 repeated, which is not a valid Ed25519 point,
+        // so this fails at key parsing rather than at signature checking. Either
+        // way it must not report success.
+        assert!(
+            err == Failure::MalformedAuthorKey || err == Failure::BadSignature,
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn steps_one_to_three_do_not_require_a_signature() {
+        let (leaves, ids, head) = log_of(3);
+        let proof = inclusion_proof(&ids, 2);
+        let out = verify(&Claim {
+            leaf: &leaves[2],
+            proof: &proof,
+            head,
+            attestation: WitnessAttestation {
+                witnessed_head: head,
+                witness_time_ms: 42,
+            },
+            signature: None,
+        })
+        .unwrap();
+        assert!(!out.author_signature_checked);
+    }
+}
+
+/// Without signature support, asking for step 4 must fail rather than silently
+/// pass. An earlier draft returned `Ok` here, which would have reported
+/// `author_signature_checked: true` having verified nothing.
+#[cfg(not(feature = "signatures"))]
+#[test]
+fn a_verifier_without_signature_support_fails_closed() {
+    let (leaves, ids, head) = log_of(3);
+    let proof = inclusion_proof(&ids, 0);
+    let sig = [0u8; 64];
+    let err = verify(&Claim {
+        leaf: &leaves[0],
+        proof: &proof,
+        head,
+        attestation: WitnessAttestation {
+            witnessed_head: head,
+            witness_time_ms: 1,
+        },
+        signature: Some(&sig),
+    })
+    .unwrap_err();
+    assert_eq!(err, Failure::SignaturesUnsupported);
+}

--- a/scripts/provenance/emit_vectors.py
+++ b/scripts/provenance/emit_vectors.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Emit the wire-format vectors as `name<TAB>hex`, matching the Rust example.
+
+Exists so CI can diff the two implementations. The unit tests on each side
+assert hardcoded expectations, so they would both keep passing if one drifted --
+each checking itself proves nothing about the format. This is the check that
+catches a fork.
+"""
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from wire_ref import *  # noqa: F403
+
+o1 = dict(tool_id='ref/1.0', ingress='paste', added=214, removed=12,
+          duration_ms=45200, op_count=87)
+o2 = dict(tool_id='ref/1.0', ingress='keystroke_stream', added=1180, removed=96,
+          duration_ms=51000, op_count=1431)
+mc2 = meta_commit([o1, o2])
+cc = content_commit(b'the quick brown fox')
+leaf = dict(seq=0, parent_head=bytes(32), content_commit=cc, meta_commit=mc2,
+            beacon_chain='bitcoin', beacon_height=880000,
+            beacon_hash=bytes.fromhex('00' * 28 + 'deadbeef'),
+            author_key=bytes.fromhex('11' * 32),
+            recovery_key=bytes.fromhex('22' * 32),
+            local_time_ms=1754000000000)
+leaves = [H(T_LEAF + bytes([i])) for i in range(5)]
+root = merkle_root(leaves)
+proof = inclusion_proof(leaves, 3)
+seg_doc = b''.join(bytes([i]) * 1024 for i in (1, 2, 3))
+
+out = [
+    ('observation0', hexs(encode_observation(**o1))),
+    ('obs_leaf0', hexs(observation_leaf(**o1))),
+    ('obs_leaf1', hexs(observation_leaf(**o2))),
+    ('meta_commit1', hexs(meta_commit([o1]))),
+    ('meta_commit2', hexs(mc2)),
+    ('content_commit', hexs(cc)),
+    ('seg_root', hexs(content_commit(seg_doc))),
+    ('leaf_body', hexs(encode_leaf_body(**leaf))),
+    ('leaf_id', hexs(leaf_id(**leaf))),
+]
+out += [(f'leaf{i}', hexs(l)) for i, l in enumerate(leaves)]
+out.append(('merkle_root', hexs(root)))
+out += [(f'proof{i}', f'{s.decode()}:{hexs(h)}') for i, (s, h) in enumerate(proof)]
+
+for name, value in out:
+    print(f'{name}\t{value}')


### PR DESCRIPTION
> Stacked on #103 → #102. Merge those first.

You asked whether the right tests run and whether the skips are appropriate. **The skips are correct** — path-filtered skipping is right. The problem is what has *no filter to skip on*.

## The finding

**#102 and #103 went green having compiled none of their code.** No workflow mentions `cargo`, `rustup` or a toolchain anywhere. Every substantive job skipped; what passed was `Detect Changes`, `PR Summary` and `Integration Tests`, none of which touch Rust.

Same gap for `wordpress-plugin` — the PHPUnit suite #90 added has **never run in CI.**

## What this adds

| Filter | Job |
| --- | --- |
| `provenance/**`, `scripts/provenance/**` | fmt, clippy `-D warnings`, tests, tests without optional features, wasm32 build, **cross-implementation check** |
| `wordpress-plugin/**` | `php -l` + PHPUnit |
| `creative-commons-chain/**` | Go build under `GOTOOLCHAIN: local` |
| `verification-service/**` | build |

The provenance job sets **no toolchain version** on purpose — `provenance/rust-toolchain.toml` is the single source of truth, so CI can't drift from a developer machine the way `go.mod` and the Dockerfile did.

## The job that matters most

Each side's tests assert **hardcoded** expectations. So the Python reference and the Rust crate would both keep passing if one drifted — **an implementation checking itself proves nothing about a wire format.**

A new Rust example and a matching Python emitter print the same 18 vectors as `name<TAB>hex`, and CI diffs them.

I verified it catches a real fork by changing `SEGMENT_SIZE` from 1024 to 512 in the reference — a plausible-looking edit that passes both suites individually:

```
7c7
< seg_root  7c43c4438a53da2125871ad58575ecc99c4754a2e40424630b96ab30e524eb35
---
> seg_root  6f530589075448eb1369f2188bf4115e04aeafe4f73954c49dbfbb5b3cbaabc9
```

## A hole I left last week

`PR Summary` is the aggregate gate — it exits non-zero if any non-skipped job failed. **`blockchain-docker-build` was never in its `needs` list.**

So the job I wrote specifically to catch broken validator images before merge *could have failed without blocking the PR*. All 16 jobs are now wired into `needs`, the rendered summary, and the failure loop.

## Deliberately not covered: `ccc-core` and `daon-core/ccc-core`

Both fail to build — `undefined: GenesisState`, `Params`, `MsgUpdateParams`. Their generated protobuf was never committed: `daon-core` has 6 `.pb.go` files, `ccc-core` has **zero**.

They also declare the *same module path as each other*, no workflow or compose file references them, and nothing outside themselves imports them. They're dead duplicated code contributing roughly **60 of the repo's Go advisories**.

Adding a permanently-red job would only train people to ignore red. **They want deleting** — separate decision, separate PR.

## Verified

Every step dry-run locally before committing: fmt, clippy, both test configurations, wasm build, reference self-check, and the cross-implementation diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)