### PR TITLE
chore(deps): drop the Renovate schedule while confirming it can see this repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,6 @@
   "dependencyDashboard": true,
   "labels": ["dependencies"],
   "reviewers": ["@daon-network/maintainers"],
-  "schedule": ["every monday at 6am"],
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["every monday at 6am"]


### PR DESCRIPTION
One line removed. Diagnostic, not a policy change.

## The evidence

Since #96 pointed Renovate at `main` on **7 August**:

```
issues by renovate:   0     ← the Dependency Dashboard enabled in #96
PRs by renovate:      0
renovate branches:    0
```

Monday 10 August came and went. The config on `main` is correct — `baseBranches: ["main"]`, `dependencyDashboard: true`.

**The missing dashboard is the informative part.** Renovate opens that issue as soon as it can read a repository — it's the cheapest artifact it produces. Its absence suggests the app can't see this repo at all, rather than that it ran and found nothing (which would be odd anyway, with 64 open advisories).

## Most likely cause

**Installation scope.** The app installed against the account or org with *"Only select repositories"*, and `daon` never added to the list. That reads as installed from the app's settings page while having no access here.

Worth checking at **github.com/settings/installations** → Renovate → Repository access (or the org's GitHub Apps settings for an org-owned repo). I can't verify it from here — that API needs the app's own credentials.

## Why remove the schedule

A weekly window is a poor loop for diagnosing this: each attempt costs seven days. Without it, Renovate runs on its normal cadence once it can see the repo — so either the dashboard appears within the hour, or **access is confirmed as the problem rather than timing.**

`lockFileMaintenance` keeps its own weekly schedule. That one is genuinely periodic and isn't what's being diagnosed.

**Restore `"schedule": ["every monday at 6am"]` once the dashboard issue exists.**

## Deliberately not done

No explanatory key added to the JSON. Renovate reports unknown config options as errors, and breaking its config while trying to start it would be a poor trade. The reasoning lives here and in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)