### PR TITLE
feat(provenance): agent store — append-only log and content-addressed blobs

### DIFF
--- a/provenance/Cargo.lock
+++ b/provenance/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +69,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "daon-provenance-agent"
+version = "0.0.0"
+dependencies = [
+ "daon-provenance-core",
+ "ed25519-dalek",
+ "hex",
+ "rand",
+ "tempfile",
+]
+
+[[package]]
 name = "daon-provenance-core"
 version = "0.0.0"
 dependencies = [
@@ -104,9 +121,26 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "rand_core",
  "sha2",
  "subtle",
 ]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fiat-crypto"
@@ -125,10 +159,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -149,12 +232,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -198,6 +330,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,3 +359,44 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/provenance/Cargo.toml
+++ b/provenance/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["core", "verify"]
+members = ["core", "verify", "agent"]
 
 [workspace.package]
 edition = "2021"
@@ -12,3 +12,5 @@ repository = "https://github.com/daon-network/daon"
 sha2 = { version = "0.10", default-features = false }
 ed25519-dalek = { version = "2", default-features = false }
 daon-provenance-core = { path = "core", default-features = false }
+hex = "0.4"
+tempfile = "3"

--- a/provenance/agent/Cargo.toml
+++ b/provenance/agent/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "daon-provenance-agent"
+version = "0.0.0"          # not published; the wire format is not frozen yet
+description = "Local store and leaf construction for DAON provenance versioning"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+daon-provenance-core.workspace = true
+hex.workspace = true
+
+[dev-dependencies]
+ed25519-dalek = { workspace = true, features = ["rand_core"] }
+tempfile.workspace = true
+rand = "0.8"

--- a/provenance/agent/src/lib.rs
+++ b/provenance/agent/src/lib.rs
@@ -1,0 +1,352 @@
+//! Local store and leaf construction for DAON provenance versioning.
+//!
+//! This is a **library**, not a daemon. iOS forbids background processes and
+//! cross-app sockets, so the agent has to be linkable directly into an app; a
+//! CLI and a desktop daemon are shells around this, not the other way round.
+//!
+//! # What lives here and what does not
+//!
+//! Here: the append-only leaf log, the content-addressed blob store, and leaf
+//! construction against [`daon_provenance_core`].
+//!
+//! Not here, deliberately:
+//!
+//! - **Witnessing.** Nothing in this crate reaches OpenTimestamps. Witness
+//!   submission is batched process-wide and rate limited, and a library that
+//!   could witness would hand every consumer a way around that.
+//! - **Key material.** [`Signer`] is a trait. The keychain-backed implementation
+//!   is platform code that belongs above this layer, and tests use an in-memory
+//!   signer, so nothing here can accidentally read a private key from disk.
+//! - **Coalescing and rate limits.** Policy, layered on top. This crate appends
+//!   exactly what it is asked to.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use daon_provenance_core::{
+    content_commit, inclusion_proof, merkle_root, meta_commit, tag, Beacon, Hash, Observation,
+    ProofStep, RevisionLeaf, SEGMENT_SIZE,
+};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Anything that can sign a leaf without surrendering the key.
+///
+/// A trait rather than a key, so the private key can live in an OS keychain — or
+/// a Secure Enclave, if the format ever supports one — and never enter this
+/// crate's memory. Implementations sign `leaf_id`, never the leaf body.
+pub trait Signer {
+    /// Ed25519 public key, committed as `author_key`.
+    fn author_key(&self) -> Hash;
+    /// Ed25519 public key committed as `recovery_key`.
+    ///
+    /// Returning 32 zero bytes marks the entity unrecoverable, which the wire
+    /// format permits and which an agent should make the creator opt into
+    /// rather than choose for them.
+    fn recovery_key(&self) -> Hash;
+    /// Sign a leaf id.
+    fn sign(&self, leaf_id: &Hash) -> [u8; 64];
+}
+
+/// Something the store could not do.
+#[derive(Debug)]
+pub enum Error {
+    /// Filesystem failure.
+    Io(std::io::Error),
+    /// The entity has no leaves, so it has no head.
+    EmptyEntity,
+    /// A leaf was requested that this entity does not have.
+    NoSuchLeaf(u64),
+    /// A stored leaf is not the expected size, so the store is damaged.
+    CorruptLeaf {
+        /// Sequence number of the offending leaf.
+        seq: u64,
+        /// Bytes actually found.
+        len: usize,
+    },
+    /// A leaf must commit to at least one observation.
+    NoObservations,
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Io(e) => write!(f, "io: {e}"),
+            Error::EmptyEntity => write!(f, "entity has no leaves"),
+            Error::NoSuchLeaf(s) => write!(f, "no leaf at seq {s}"),
+            Error::CorruptLeaf { seq, len } => {
+                write!(f, "leaf {seq} is {len} bytes, expected 218")
+            }
+            Error::NoObservations => write!(f, "a leaf must commit to at least one observation"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// A stored revision: the leaf itself plus the signature over its id.
+///
+/// Carried together because the signature is excluded from the hashed body, so
+/// it cannot be recovered from the leaf.
+#[derive(Debug, Clone)]
+pub struct StoredLeaf {
+    /// The leaf.
+    pub leaf: RevisionLeaf,
+    /// Ed25519 signature over `leaf.leaf_id()`.
+    pub signature: [u8; 64],
+}
+
+/// An on-disk store for one creator's entities.
+///
+/// Layout:
+///
+/// ```text
+/// <root>/
+///   blobs/<first two hex>/<full hex>     content segments, deduplicated
+///   entities/<entity_id hex>/
+///     leaves/<seq padded to 20>.leaf     218-byte body
+///     leaves/<seq padded to 20>.sig      64-byte signature
+/// ```
+///
+/// Segments are the unit of storage because they are already the unit of
+/// commitment, so deduplication falls out: an unchanged 1 KiB run costs nothing
+/// on the next revision. For a manuscript edited in place that is most of it.
+pub struct Store {
+    root: PathBuf,
+}
+
+fn hex32(h: &Hash) -> String {
+    hex::encode(h)
+}
+
+impl Store {
+    /// Open or create a store rooted at `path`.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, Error> {
+        let root = path.as_ref().to_path_buf();
+        fs::create_dir_all(root.join("blobs"))?;
+        fs::create_dir_all(root.join("entities"))?;
+        Ok(Store { root })
+    }
+
+    fn blob_path(&self, h: &Hash) -> PathBuf {
+        let s = hex32(h);
+        self.root.join("blobs").join(&s[..2]).join(&s)
+    }
+
+    fn entity_dir(&self, entity: &Hash) -> PathBuf {
+        self.root.join("entities").join(hex32(entity))
+    }
+
+    fn leaf_path(&self, entity: &Hash, seq: u64, ext: &str) -> PathBuf {
+        self.entity_dir(entity)
+            .join("leaves")
+            .join(format!("{seq:020}.{ext}"))
+    }
+
+    /// Write bytes to a path atomically: a partial write must never be mistaken
+    /// for a complete one, since a truncated leaf would fail verification in a
+    /// way that looks like tampering.
+    fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), Error> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let tmp = path.with_extension("tmp");
+        {
+            let mut f = fs::File::create(&tmp)?;
+            f.write_all(bytes)?;
+            f.sync_all()?;
+        }
+        fs::rename(&tmp, path)?;
+        Ok(())
+    }
+
+    /// Store a revision's content, one blob per segment.
+    ///
+    /// Returns the `content_commit` for the whole content. Segments already
+    /// present are not rewritten, so an edit that touches one paragraph costs
+    /// one segment rather than a copy of the manuscript.
+    pub fn put_content(&self, content: &[u8]) -> Result<Hash, Error> {
+        for seg in content.chunks(SEGMENT_SIZE.max(1)) {
+            let h = daon_provenance_core::hash_tagged(tag::CONTENT, seg);
+            let p = self.blob_path(&h);
+            if !p.exists() {
+                Self::write_atomic(&p, seg)?;
+            }
+        }
+        if content.is_empty() {
+            let h = daon_provenance_core::hash_tagged(tag::CONTENT, &[]);
+            let p = self.blob_path(&h);
+            if !p.exists() {
+                Self::write_atomic(&p, &[])?;
+            }
+        }
+        Ok(content_commit(content))
+    }
+
+    /// Number of leaves in an entity.
+    pub fn len(&self, entity: &Hash) -> Result<u64, Error> {
+        let dir = self.entity_dir(entity).join("leaves");
+        if !dir.exists() {
+            return Ok(0);
+        }
+        let mut n = 0u64;
+        for e in fs::read_dir(dir)? {
+            let e = e?;
+            if e.path().extension().is_some_and(|x| x == "leaf") {
+                n += 1;
+            }
+        }
+        Ok(n)
+    }
+
+    /// Whether an entity has no leaves.
+    pub fn is_empty(&self, entity: &Hash) -> Result<bool, Error> {
+        Ok(self.len(entity)? == 0)
+    }
+
+    /// Read one stored leaf.
+    pub fn leaf(&self, entity: &Hash, seq: u64) -> Result<StoredLeaf, Error> {
+        let body =
+            fs::read(self.leaf_path(entity, seq, "leaf")).map_err(|_| Error::NoSuchLeaf(seq))?;
+        if body.len() != daon_provenance_core::LEAF_BODY_LEN {
+            return Err(Error::CorruptLeaf {
+                seq,
+                len: body.len(),
+            });
+        }
+        let sig_bytes =
+            fs::read(self.leaf_path(entity, seq, "sig")).map_err(|_| Error::NoSuchLeaf(seq))?;
+        let mut signature = [0u8; 64];
+        signature.copy_from_slice(&sig_bytes[..64.min(sig_bytes.len())]);
+        Ok(StoredLeaf {
+            leaf: decode_leaf(&body),
+            signature,
+        })
+    }
+
+    /// Every leaf id in order. The basis for the head and for proofs.
+    pub fn leaf_ids(&self, entity: &Hash) -> Result<Vec<Hash>, Error> {
+        let n = self.len(entity)?;
+        (0..n)
+            .map(|s| Ok(self.leaf(entity, s)?.leaf.leaf_id()))
+            .collect()
+    }
+
+    /// Current head: the Merkle root over every leaf id.
+    ///
+    /// Recomputed rather than cached. At the scale one writer produces this is
+    /// cheap, and a cache is a second source of truth that can disagree with the
+    /// leaves — which for a structure whose purpose is proving what existed is a
+    /// bad trade until it is measurably necessary.
+    pub fn head(&self, entity: &Hash) -> Result<Hash, Error> {
+        let ids = self.leaf_ids(entity)?;
+        if ids.is_empty() {
+            return Err(Error::EmptyEntity);
+        }
+        Ok(merkle_root(&ids))
+    }
+
+    /// An inclusion proof for one leaf against the current head.
+    pub fn proof(&self, entity: &Hash, seq: u64) -> Result<(StoredLeaf, Vec<ProofStep>), Error> {
+        let ids = self.leaf_ids(entity)?;
+        if ids.is_empty() {
+            return Err(Error::EmptyEntity);
+        }
+        if seq as usize >= ids.len() {
+            return Err(Error::NoSuchLeaf(seq));
+        }
+        Ok((self.leaf(entity, seq)?, inclusion_proof(&ids, seq as usize)))
+    }
+
+    /// Append a revision.
+    ///
+    /// For `seq` 0 this creates the entity, whose id is the genesis leaf id —
+    /// content-addressed and immutable, so an entity cannot be renamed.
+    #[allow(clippy::too_many_arguments)]
+    pub fn append(
+        &self,
+        entity: Option<&Hash>,
+        content: &[u8],
+        observations: &[Observation],
+        beacon: Beacon,
+        signer: &dyn Signer,
+        local_time_ms: i64,
+    ) -> Result<(Hash, StoredLeaf), Error> {
+        if observations.is_empty() {
+            return Err(Error::NoObservations);
+        }
+        let cc = self.put_content(content)?;
+        let mc = meta_commit(observations).map_err(|_| Error::NoObservations)?;
+
+        let (seq, parent_head) = match entity {
+            None => (0u64, [0u8; 32]),
+            Some(e) => (self.len(e)?, self.head(e)?),
+        };
+
+        let leaf = RevisionLeaf {
+            seq,
+            parent_head,
+            content_commit: cc,
+            meta_commit: mc,
+            beacon,
+            author_key: signer.author_key(),
+            recovery_key: signer.recovery_key(),
+            local_time_ms,
+        };
+        let id = leaf.leaf_id();
+        let signature = signer.sign(&id);
+
+        // A genesis leaf's id is the entity id.
+        let entity_id = match entity {
+            None => id,
+            Some(e) => *e,
+        };
+
+        Self::write_atomic(&self.leaf_path(&entity_id, seq, "leaf"), &leaf.encode())?;
+        Self::write_atomic(&self.leaf_path(&entity_id, seq, "sig"), &signature)?;
+
+        Ok((entity_id, StoredLeaf { leaf, signature }))
+    }
+}
+
+/// Decode a leaf body. The inverse of [`RevisionLeaf::encode`].
+///
+/// Total and infallible by construction: the caller has already checked the
+/// length, and every field is fixed-width with no optionality, which is exactly
+/// why the format was specified that way.
+fn decode_leaf(b: &[u8]) -> RevisionLeaf {
+    let g32 = |o: usize| -> Hash {
+        let mut h = [0u8; 32];
+        h.copy_from_slice(&b[o..o + 32]);
+        h
+    };
+    let g8 = |o: usize| -> [u8; 8] {
+        let mut x = [0u8; 8];
+        x.copy_from_slice(&b[o..o + 8]);
+        x
+    };
+    RevisionLeaf {
+        seq: u64::from_be_bytes(g8(1)),
+        parent_head: g32(9),
+        content_commit: g32(41),
+        meta_commit: g32(73),
+        beacon: Beacon {
+            chain: match b[105] {
+                2 => daon_provenance_core::BeaconChain::Daon,
+                _ => daon_provenance_core::BeaconChain::Bitcoin,
+            },
+            height: u64::from_be_bytes(g8(106)),
+            block_hash: g32(114),
+        },
+        author_key: g32(146),
+        recovery_key: g32(178),
+        local_time_ms: i64::from_be_bytes(g8(210)),
+    }
+}

--- a/provenance/agent/tests/store.rs
+++ b/provenance/agent/tests/store.rs
@@ -1,0 +1,286 @@
+//! Tests for the agent's store.
+//!
+//! The load-bearing property is that anything the store produces verifies with
+//! the minimum verifier — a store that writes leaves nobody can check is worse
+//! than no store. So most of these end in `verify_inclusion` rather than in an
+//! assertion about the store's own bookkeeping.
+
+use daon_provenance_agent::{Error as StoreError, Signer, Store};
+use daon_provenance_core::*;
+use ed25519_dalek::{Signer as _, SigningKey};
+
+/// In-memory signer. The keychain-backed one is platform code above this layer;
+/// this exists so no test can read a private key from disk.
+struct TestSigner {
+    key: SigningKey,
+    recovery: Hash,
+}
+
+impl TestSigner {
+    fn new(seed: u8) -> Self {
+        TestSigner {
+            key: SigningKey::from_bytes(&[seed; 32]),
+            recovery: [seed.wrapping_add(100); 32],
+        }
+    }
+}
+
+impl Signer for TestSigner {
+    fn author_key(&self) -> Hash {
+        self.key.verifying_key().to_bytes()
+    }
+    fn recovery_key(&self) -> Hash {
+        self.recovery
+    }
+    fn sign(&self, leaf_id: &Hash) -> [u8; 64] {
+        self.key.sign(leaf_id).to_bytes()
+    }
+}
+
+fn obs(added: u64) -> Observation {
+    Observation {
+        tool_id: b"test/1.0".to_vec(),
+        ingress: Ingress::KeystrokeStream,
+        added,
+        removed: 0,
+        duration_ms: 1000,
+        op_count: added,
+    }
+}
+
+fn beacon() -> Beacon {
+    Beacon {
+        chain: BeaconChain::Bitcoin,
+        height: 880_000,
+        block_hash: [0xab; 32],
+    }
+}
+
+fn store() -> (tempfile::TempDir, Store) {
+    let dir = tempfile::tempdir().unwrap();
+    let s = Store::open(dir.path()).unwrap();
+    (dir, s)
+}
+
+#[test]
+fn genesis_entity_id_is_its_own_leaf_id() {
+    let (_d, s) = store();
+    let signer = TestSigner::new(7);
+    let (entity, stored) = s
+        .append(None, b"hello", &[obs(5)], beacon(), &signer, 1_000)
+        .unwrap();
+
+    assert_eq!(
+        entity,
+        stored.leaf.leaf_id(),
+        "entity id is content-addressed"
+    );
+    assert_eq!(stored.leaf.seq, 0);
+    assert_eq!(stored.leaf.parent_head, [0u8; 32], "genesis sentinel");
+}
+
+#[test]
+fn appended_leaves_chain_and_verify() {
+    let (_d, s) = store();
+    let signer = TestSigner::new(3);
+    let (entity, _) = s
+        .append(None, b"draft one", &[obs(9)], beacon(), &signer, 1)
+        .unwrap();
+
+    for i in 1..6u64 {
+        let content = format!("draft {i}");
+        let (_, stored) = s
+            .append(
+                Some(&entity),
+                content.as_bytes(),
+                &[obs(i)],
+                beacon(),
+                &signer,
+                i as i64,
+            )
+            .unwrap();
+        assert_eq!(stored.leaf.seq, i);
+    }
+
+    assert_eq!(s.len(&entity).unwrap(), 6);
+
+    // Every leaf must prove against the current head.
+    let head = s.head(&entity).unwrap();
+    for seq in 0..6u64 {
+        let (stored, proof) = s.proof(&entity, seq).unwrap();
+        assert!(
+            verify_inclusion(&stored.leaf.leaf_id(), &proof, &head),
+            "leaf {seq} must prove under the head"
+        );
+    }
+}
+
+#[test]
+fn a_leaf_recovers_byte_identically_from_disk() {
+    let (_d, s) = store();
+    let signer = TestSigner::new(11);
+    let (entity, written) = s
+        .append(None, b"content", &[obs(7)], beacon(), &signer, -5_000)
+        .unwrap();
+
+    let read = s.leaf(&entity, 0).unwrap();
+    assert_eq!(
+        read.leaf.encode(),
+        written.leaf.encode(),
+        "body round-trips"
+    );
+    assert_eq!(read.leaf.leaf_id(), written.leaf.leaf_id());
+    assert_eq!(read.signature, written.signature);
+    assert_eq!(
+        read.leaf.local_time_ms, -5_000,
+        "negative local_time survives: it is untrusted and must hold nonsense"
+    );
+}
+
+#[test]
+fn signatures_verify_against_the_committed_author_key() {
+    use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+    let (_d, s) = store();
+    let signer = TestSigner::new(23);
+    let (entity, _) = s
+        .append(None, b"signed", &[obs(1)], beacon(), &signer, 1)
+        .unwrap();
+
+    let stored = s.leaf(&entity, 0).unwrap();
+    let vk = VerifyingKey::from_bytes(&stored.leaf.author_key).unwrap();
+    assert!(vk
+        .verify(
+            &stored.leaf.leaf_id(),
+            &Signature::from_bytes(&stored.signature)
+        )
+        .is_ok());
+}
+
+#[test]
+fn content_segments_are_deduplicated() {
+    let (dir, s) = store();
+    let big = vec![b'x'; SEGMENT_SIZE * 3];
+    s.put_content(&big).unwrap();
+    let count = |d: &std::path::Path| walkdir(d.join("blobs")).len();
+    let after_first = count(dir.path());
+
+    // Same content again: no new blobs.
+    s.put_content(&big).unwrap();
+    assert_eq!(
+        count(dir.path()),
+        after_first,
+        "identical content adds nothing"
+    );
+
+    // Change only the final segment: exactly one new blob.
+    let mut edited = big.clone();
+    *edited.last_mut().unwrap() = b'y';
+    s.put_content(&edited).unwrap();
+    assert_eq!(
+        count(dir.path()),
+        after_first + 1,
+        "editing one segment costs one segment, not a copy of the document"
+    );
+}
+
+fn walkdir(p: std::path::PathBuf) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(rd) = std::fs::read_dir(&p) {
+        for e in rd.flatten() {
+            let path = e.path();
+            if path.is_dir() {
+                out.extend(walkdir(path));
+            } else {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn content_commit_matches_the_core_crate() {
+    let (_d, s) = store();
+    let content = b"the store must not invent its own commitment";
+    assert_eq!(
+        s.put_content(content).unwrap(),
+        content_commit(content),
+        "the store commits exactly what the format says"
+    );
+}
+
+#[test]
+fn empty_entity_has_no_head() {
+    let (_d, s) = store();
+    let missing = [0x99u8; 32];
+    assert!(matches!(s.head(&missing), Err(StoreError::EmptyEntity)));
+    assert!(s.is_empty(&missing).unwrap());
+}
+
+#[test]
+fn a_leaf_must_commit_to_at_least_one_observation() {
+    let (_d, s) = store();
+    let signer = TestSigner::new(1);
+    assert!(matches!(
+        s.append(None, b"x", &[], beacon(), &signer, 1),
+        Err(StoreError::NoObservations)
+    ));
+}
+
+#[test]
+fn reopening_the_store_sees_prior_leaves() {
+    let dir = tempfile::tempdir().unwrap();
+    let signer = TestSigner::new(42);
+    let entity = {
+        let s = Store::open(dir.path()).unwrap();
+        let (e, _) = s
+            .append(None, b"first", &[obs(1)], beacon(), &signer, 1)
+            .unwrap();
+        s.append(Some(&e), b"second", &[obs(2)], beacon(), &signer, 2)
+            .unwrap();
+        e
+    };
+
+    let s = Store::open(dir.path()).unwrap();
+    assert_eq!(
+        s.len(&entity).unwrap(),
+        2,
+        "state is on disk, not in memory"
+    );
+    let head = s.head(&entity).unwrap();
+    let (stored, proof) = s.proof(&entity, 1).unwrap();
+    assert!(verify_inclusion(&stored.leaf.leaf_id(), &proof, &head));
+}
+
+#[test]
+fn a_tampered_leaf_on_disk_fails_its_proof() {
+    let dir = tempfile::tempdir().unwrap();
+    let signer = TestSigner::new(5);
+    let s = Store::open(dir.path()).unwrap();
+    let (entity, _) = s
+        .append(None, b"a", &[obs(1)], beacon(), &signer, 1)
+        .unwrap();
+    for i in 1..4u64 {
+        s.append(Some(&entity), b"b", &[obs(i)], beacon(), &signer, i as i64)
+            .unwrap();
+    }
+    let head = s.head(&entity).unwrap();
+    let (before, proof) = s.proof(&entity, 1).unwrap();
+    assert!(verify_inclusion(&before.leaf.leaf_id(), &proof, &head));
+
+    // Flip one byte of a stored leaf body.
+    let path = walkdir(dir.path().join("entities"))
+        .into_iter()
+        .find(|p| p.to_string_lossy().ends_with("00000000000000000001.leaf"))
+        .expect("leaf 1 on disk");
+    let mut bytes = std::fs::read(&path).unwrap();
+    bytes[210] ^= 0x01; // one bit of local_time_ms
+    std::fs::write(&path, &bytes).unwrap();
+
+    let after = Store::open(dir.path()).unwrap().leaf(&entity, 1).unwrap();
+    assert_ne!(after.leaf.leaf_id(), before.leaf.leaf_id());
+    assert!(
+        !verify_inclusion(&after.leaf.leaf_id(), &proof, &head),
+        "a tampered leaf must not prove under the old head"
+    );
+}


### PR DESCRIPTION
First piece of the agent, with your two decisions applied: **OS keychain** for keys (via a `Signer` trait — the platform code sits above this), **content-addressed blobs** for content.

| | |
| --- | --- |
| Tests | **10 passed** |
| clippy `-D warnings` | clean |
| fmt | clean |
| cross-implementation check | still agrees |

## A library, not a daemon

iOS forbids background processes and cross-app sockets, so the agent has to be **linkable directly into an app**. The CLI and desktop daemon are shells around this, not the other way round.

Going straight to a daemon would have meant building session handling and socket transport around a core that had never been exercised.

## Storage follows the format

Content is stored **one blob per segment**, because segments are already the unit of commitment. Deduplication falls out: editing one paragraph costs one 1 KiB segment, not a copy of the manuscript. There's a test asserting exactly that.

The head is **recomputed, not cached**. At one writer's scale that's cheap, and a cache is a second source of truth that can disagree with the leaves — a bad trade for a structure whose purpose is proving what existed.

Writes go through a temp file and a rename. A partial write must never be mistaken for a complete one: **a truncated leaf fails verification in a way that looks exactly like tampering.**

## Deliberately absent

**Witnessing.** Nothing here reaches OpenTimestamps. Submission is batched process-wide and rate limited; a library that could witness would hand every consumer a way around that.

**Key material.** `Signer` is a trait, so the private key lives in the keychain and never enters this crate's memory. Tests use an in-memory signer, so nothing here can read a key from disk even by accident.

**Coalescing and rate limits.** Policy, layered above. This crate appends exactly what it's asked to.

## The tests

Most end in `verify_inclusion` rather than asserting the store's own bookkeeping — **a store that writes leaves nobody can check is worse than no store.**

- genesis entity id is its own leaf id (content-addressed, unrenameable)
- leaves chain and every one proves under the head
- byte-identical round-trip through disk, including a **negative** `local_time_ms` — it's untrusted and must hold nonsense
- signatures verify against the committed `author_key`
- segment dedup: same content adds nothing, one edited segment adds exactly one blob
- reopening a store sees prior leaves — state is on disk, not in memory
- **a one-bit tamper on a stored leaf fails its proof**

## Next

Keychain-backed `Signer`, then coalescing and rate limits, then OpenTimestamps. Each is separable, and the store is what they all build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)