### PR TITLE
feat(provenance): witnessing — OpenTimestamps, batching, and the anchor the verifier needs

### DIFF
--- a/provenance/Cargo.lock
+++ b/provenance/Cargo.lock
@@ -101,6 +101,8 @@ version = "0.0.0"
 dependencies = [
  "apple-native-keyring-store",
  "daon-provenance-core",
+ "daon-provenance-verify",
+ "daon-provenance-witness",
  "ed25519-dalek",
  "hex",
  "keyring-core",
@@ -121,6 +123,16 @@ version = "0.0.0"
 dependencies = [
  "daon-provenance-core",
  "ed25519-dalek",
+]
+
+[[package]]
+name = "daon-provenance-witness"
+version = "0.0.0"
+dependencies = [
+ "daon-provenance-core",
+ "hex",
+ "ripemd",
+ "sha2",
 ]
 
 [[package]]
@@ -309,6 +321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest",
 ]
 
 [[package]]

--- a/provenance/Cargo.toml
+++ b/provenance/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["core", "verify", "agent"]
+members = ["core", "verify", "agent", "witness"]
 
 [workspace.package]
 edition = "2021"
@@ -12,6 +12,7 @@ repository = "https://github.com/daon-network/daon"
 sha2 = { version = "0.10", default-features = false }
 ed25519-dalek = { version = "2", default-features = false }
 daon-provenance-core = { path = "core", default-features = false }
+daon-provenance-witness = { path = "witness", default-features = false }
 hex = "0.4"
 tempfile = "3"
 # Registering the protected (data-protection) store ourselves means talking to

--- a/provenance/agent/Cargo.toml
+++ b/provenance/agent/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 daon-provenance-core.workspace = true
+daon-provenance-witness.workspace = true
 hex.workspace = true
 # Only pulled in by the `keychain` feature. The store itself stays free of
 # platform code so it can be tested anywhere, including in CI on Linux.
@@ -34,7 +35,14 @@ keychain = [
     "dep:apple-native-keyring-store",
 ]
 
+# Reports the resolved credential store, which only exists with the feature that
+# provides one.
+[[example]]
+name = "backend"
+required-features = ["keychain"]
+
 [dev-dependencies]
+daon-provenance-verify = { path = "../verify" }
 ed25519-dalek = { workspace = true, features = ["rand_core"] }
 tempfile.workspace = true
 rand = "0.8"

--- a/provenance/agent/src/lib.rs
+++ b/provenance/agent/src/lib.rs
@@ -28,6 +28,7 @@ pub mod keychain;
 #[cfg(feature = "keychain")]
 pub mod keystore;
 pub mod policy;
+pub mod witness;
 
 use daon_provenance_core::{
     content_commit, inclusion_proof, merkle_root, meta_commit, tag, Beacon, Hash, Observation,
@@ -73,6 +74,11 @@ pub enum Error {
     },
     /// A leaf must commit to at least one observation.
     NoObservations,
+    /// Witness state on disk is not the shape this code writes.
+    ///
+    /// Carries what was being read rather than an offset, because the useful
+    /// question when this fires is which file to look at, not which byte.
+    Malformed(&'static str),
 }
 
 impl From<std::io::Error> for Error {
@@ -87,6 +93,7 @@ impl std::fmt::Display for Error {
             Error::Io(e) => write!(f, "io: {e}"),
             Error::EmptyEntity => write!(f, "entity has no leaves"),
             Error::NoSuchLeaf(s) => write!(f, "no leaf at seq {s}"),
+            Error::Malformed(what) => write!(f, "malformed {what}"),
             Error::CorruptLeaf { seq, len } => {
                 write!(f, "leaf {seq} is {len} bytes, expected 218")
             }

--- a/provenance/agent/src/witness.rs
+++ b/provenance/agent/src/witness.rs
@@ -1,0 +1,310 @@
+//! Persisting witness state alongside the log.
+//!
+//! [`crate::Store`] holds what the creator wrote. This holds what has been
+//! *proven about when they wrote it*, which is separate data with a separate
+//! lifecycle: a head exists the moment it is appended, and stays unwitnessed for
+//! minutes or hours afterwards.
+//!
+//! ```text
+//!   <root>/witness/pending/<head hex>       when the head entered a batch (ms)
+//!          batches/<root hex>.ots           the proof, pending then upgraded
+//!          batches/<root hex>.members       head, index and inclusion proof
+//!          submitted                        last submission time (ms)
+//! ```
+//!
+//! # Why proofs are stored by batch root, not by head
+//!
+//! One proof covers many heads. Storing a copy per head would duplicate it and,
+//! worse, invite the two copies to disagree after an upgrade. Each head instead
+//! records which batch it is in, and the batch owns the proof.
+//!
+//! # No network here either
+//!
+//! This module writes files. Submitting a sealed root to a calendar, and
+//! fetching the upgraded proof later, belong to whatever the agent uses for
+//! transport — see the note in `daon-provenance-witness`.
+
+use crate::Error;
+use daon_provenance_core::{Hash, ProofStep, Side};
+use daon_provenance_witness::batch::{Batch, BatchMembership, BatchPolicy, SealedBatch};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Witness state for one store.
+pub struct WitnessLog {
+    root: PathBuf,
+}
+
+/// A head that is waiting to be witnessed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PendingHead {
+    /// The head.
+    pub head: Hash,
+    /// When it was queued, by the agent's local clock in milliseconds.
+    ///
+    /// Used only to decide when to submit. It is never evidence — the witness
+    /// time comes from a Bitcoin header.
+    pub queued_ms: i64,
+}
+
+impl WitnessLog {
+    /// Open or create witness state under a store root.
+    pub fn open(store_root: impl AsRef<Path>) -> Result<Self, Error> {
+        let root = store_root.as_ref().join("witness");
+        fs::create_dir_all(root.join("pending"))?;
+        fs::create_dir_all(root.join("batches"))?;
+        Ok(WitnessLog { root })
+    }
+
+    /// Queue a head for witnessing.
+    ///
+    /// Idempotent: re-queuing a head that is already pending keeps the original
+    /// timestamp, so an agent that re-scans its log on startup cannot make an
+    /// old head look freshly queued and postpone its anchor indefinitely.
+    pub fn queue(&self, head: &Hash, now_ms: i64) -> Result<(), Error> {
+        let path = self.pending_path(head);
+        if path.exists() {
+            return Ok(());
+        }
+        write_atomic(&path, now_ms.to_string().as_bytes())
+    }
+
+    /// Every head waiting to be witnessed, oldest first.
+    pub fn pending(&self) -> Result<Vec<PendingHead>, Error> {
+        let mut out = Vec::new();
+        for entry in fs::read_dir(self.root.join("pending"))? {
+            let entry = entry?;
+            let name = entry.file_name();
+            let Some(head) = name.to_str().and_then(parse_hash) else {
+                continue;
+            };
+            let queued_ms = fs::read_to_string(entry.path())?
+                .trim()
+                .parse::<i64>()
+                .map_err(|_| Error::Malformed("witness queue timestamp"))?;
+            out.push(PendingHead { head, queued_ms });
+        }
+        // Ties broken by head so the order is deterministic, which keeps the
+        // batch root reproducible from the same set of files.
+        out.sort_by_key(|p| (p.queued_ms, p.head));
+        Ok(out)
+    }
+
+    /// When the last batch was submitted, if ever.
+    pub fn last_submitted_ms(&self) -> Result<Option<i64>, Error> {
+        let path = self.root.join("submitted");
+        if !path.exists() {
+            return Ok(None);
+        }
+        Ok(Some(
+            fs::read_to_string(path)?
+                .trim()
+                .parse::<i64>()
+                .map_err(|_| Error::Malformed("witness submitted timestamp"))?,
+        ))
+    }
+
+    /// Whether policy says to submit now, given what is pending.
+    pub fn should_submit(&self, policy: &BatchPolicy, now_ms: i64) -> Result<bool, Error> {
+        let pending = self.pending()?;
+        let mut batch = Batch::new();
+        for p in &pending {
+            batch.push(p.head);
+        }
+        Ok(policy.should_submit(
+            &batch,
+            pending.first().map(|p| p.queued_ms),
+            self.last_submitted_ms()?,
+            now_ms,
+        ))
+    }
+
+    /// Seal everything pending into a batch ready for submission.
+    ///
+    /// Does not clear the pending set. A head stays pending until its proof
+    /// actually carries a Bitcoin attestation, because a submission that is
+    /// lost, rejected or left pending forever must not silently drop the head.
+    pub fn seal(&self) -> Result<Option<SealedBatch>, Error> {
+        let mut batch = Batch::new();
+        for p in self.pending()? {
+            batch.push(p.head);
+        }
+        Ok(batch.seal())
+    }
+
+    /// Record a submitted batch and its proof.
+    ///
+    /// The proof at this stage is normally *pending* — a receipt, not a
+    /// timestamp. Call again with the upgraded bytes once it carries a Bitcoin
+    /// attestation.
+    pub fn record(
+        &self,
+        sealed: &SealedBatch,
+        proof_ots: &[u8],
+        submitted_ms: i64,
+    ) -> Result<(), Error> {
+        // A membership that does not verify would be worthless later, when
+        // nobody is around to notice why.
+        for m in &sealed.members {
+            if !sealed.verify_member(m) {
+                return Err(Error::Malformed("batch membership does not prove"));
+            }
+        }
+        write_atomic(&self.proof_path(&sealed.root), proof_ots)?;
+        write_atomic(&self.members_path(&sealed.root), &encode_members(sealed)?)?;
+        write_atomic(
+            &self.root.join("submitted"),
+            submitted_ms.to_string().as_bytes(),
+        )
+    }
+
+    /// Replace a batch's proof with an upgraded one.
+    pub fn upgrade(&self, batch_root: &Hash, proof_ots: &[u8]) -> Result<(), Error> {
+        let path = self.proof_path(batch_root);
+        if !path.exists() {
+            return Err(Error::Malformed("no such batch"));
+        }
+        write_atomic(&path, proof_ots)
+    }
+
+    /// A batch's stored proof bytes.
+    pub fn proof(&self, batch_root: &Hash) -> Result<Vec<u8>, Error> {
+        Ok(fs::read(self.proof_path(batch_root))?)
+    }
+
+    /// A batch's stored memberships.
+    pub fn members(&self, batch_root: &Hash) -> Result<Vec<BatchMembership>, Error> {
+        decode_members(&fs::read(self.members_path(batch_root))?)
+    }
+
+    /// Every batch root that has a stored proof.
+    pub fn batches(&self) -> Result<Vec<Hash>, Error> {
+        let mut out = Vec::new();
+        for entry in fs::read_dir(self.root.join("batches"))? {
+            let name = entry?.file_name();
+            let Some(stem) = name.to_str().and_then(|n| n.strip_suffix(".ots")) else {
+                continue;
+            };
+            if let Some(h) = parse_hash(stem) {
+                out.push(h);
+            }
+        }
+        out.sort();
+        Ok(out)
+    }
+
+    /// Stop tracking a head as pending, once its batch proof is anchored.
+    pub fn resolve(&self, head: &Hash) -> Result<(), Error> {
+        let path = self.pending_path(head);
+        if path.exists() {
+            fs::remove_file(path)?;
+        }
+        Ok(())
+    }
+
+    fn pending_path(&self, head: &Hash) -> PathBuf {
+        self.root.join("pending").join(hex(head))
+    }
+
+    fn proof_path(&self, batch_root: &Hash) -> PathBuf {
+        self.root
+            .join("batches")
+            .join(format!("{}.ots", hex(batch_root)))
+    }
+
+    fn members_path(&self, batch_root: &Hash) -> PathBuf {
+        self.root
+            .join("batches")
+            .join(format!("{}.members", hex(batch_root)))
+    }
+}
+
+// ── membership encoding ───────────────────────────────────────────────────
+//
+// Fixed-width and self-describing, matching the rest of the project: no serde,
+// no format that can drift between versions without anyone noticing.
+//
+//   u32 BE   member count
+//   per member:
+//     32     head
+//     u32 BE index
+//     u32 BE proof step count
+//     per step: 1 byte side (0 left, 1 right) + 32 bytes hash
+
+fn encode_members(sealed: &SealedBatch) -> Result<Vec<u8>, Error> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&(sealed.members.len() as u32).to_be_bytes());
+    for m in &sealed.members {
+        out.extend_from_slice(&m.head);
+        out.extend_from_slice(&(m.index as u32).to_be_bytes());
+        out.extend_from_slice(&(m.proof.len() as u32).to_be_bytes());
+        for (side, hash) in &m.proof {
+            out.push(match side {
+                Side::Left => 0,
+                Side::Right => 1,
+            });
+            out.extend_from_slice(hash);
+        }
+    }
+    Ok(out)
+}
+
+fn decode_members(bytes: &[u8]) -> Result<Vec<BatchMembership>, Error> {
+    let mut c = 0usize;
+    let mut take = |n: usize| -> Result<&[u8], Error> {
+        let s = bytes
+            .get(c..c + n)
+            .ok_or(Error::Malformed("batch members truncated"))?;
+        c += n;
+        Ok(s)
+    };
+    let count = u32::from_be_bytes(take(4)?.try_into().unwrap()) as usize;
+    let mut out = Vec::with_capacity(count.min(1024));
+    for _ in 0..count {
+        let head: Hash = take(32)?.try_into().unwrap();
+        let index = u32::from_be_bytes(take(4)?.try_into().unwrap()) as usize;
+        let steps = u32::from_be_bytes(take(4)?.try_into().unwrap()) as usize;
+        let mut proof: Vec<ProofStep> = Vec::with_capacity(steps.min(64));
+        for _ in 0..steps {
+            let side = match take(1)?[0] {
+                0 => Side::Left,
+                1 => Side::Right,
+                _ => return Err(Error::Malformed("batch member proof side")),
+            };
+            let hash: Hash = take(32)?.try_into().unwrap();
+            proof.push((side, hash));
+        }
+        out.push(BatchMembership { head, index, proof });
+    }
+    if c != bytes.len() {
+        return Err(Error::Malformed("trailing bytes in batch members"));
+    }
+    Ok(out)
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+fn hex(h: &Hash) -> String {
+    h.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn parse_hash(s: &str) -> Option<Hash> {
+    if s.len() != 64 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(s.get(i * 2..i * 2 + 2)?, 16).ok()?;
+    }
+    Some(out)
+}
+
+/// Write via a temporary file and rename, so a crash mid-write leaves the
+/// previous contents rather than a half-file. An upgraded proof replacing a
+/// pending one is exactly when this matters.
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), Error> {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes)?;
+    fs::rename(&tmp, path)?;
+    Ok(())
+}

--- a/provenance/agent/tests/witness.rs
+++ b/provenance/agent/tests/witness.rs
@@ -1,0 +1,230 @@
+//! Witness state, and the end-to-end path from a local leaf to a checkable claim.
+
+use daon_provenance_agent::witness::WitnessLog;
+use daon_provenance_witness::batch::BatchPolicy;
+use tempfile::TempDir;
+
+fn head(b: u8) -> [u8; 32] {
+    [b; 32]
+}
+
+fn log() -> (TempDir, WitnessLog) {
+    let dir = TempDir::new().unwrap();
+    let log = WitnessLog::open(dir.path()).unwrap();
+    (dir, log)
+}
+
+#[test]
+fn queued_heads_come_back_oldest_first() {
+    let (_d, log) = log();
+    log.queue(&head(3), 300).unwrap();
+    log.queue(&head(1), 100).unwrap();
+    log.queue(&head(2), 200).unwrap();
+
+    let pending = log.pending().unwrap();
+    assert_eq!(
+        pending.iter().map(|p| p.queued_ms).collect::<Vec<_>>(),
+        vec![100, 200, 300]
+    );
+}
+
+/// Re-queuing must not refresh the timestamp. An agent that re-scans its log on
+/// every start would otherwise keep pushing the deadline back and never anchor.
+#[test]
+fn requeuing_keeps_the_original_timestamp() {
+    let (_d, log) = log();
+    log.queue(&head(1), 100).unwrap();
+    log.queue(&head(1), 999_999).unwrap();
+
+    let pending = log.pending().unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].queued_ms, 100);
+}
+
+#[test]
+fn sealing_covers_everything_pending() {
+    let (_d, log) = log();
+    for i in 0..6u8 {
+        log.queue(&head(i), i as i64).unwrap();
+    }
+    let sealed = log.seal().unwrap().expect("sealed");
+    assert_eq!(sealed.members.len(), 6);
+    for m in &sealed.members {
+        assert!(sealed.verify_member(m));
+    }
+}
+
+#[test]
+fn nothing_pending_seals_to_nothing() {
+    let (_d, log) = log();
+    assert!(log.seal().unwrap().is_none());
+}
+
+/// A head stays pending until its proof is actually anchored. Submission alone
+/// is not resolution -- a request can be lost or sit pending forever.
+#[test]
+fn recording_a_submission_does_not_resolve_the_heads() {
+    let (_d, log) = log();
+    log.queue(&head(1), 10).unwrap();
+    let sealed = log.seal().unwrap().unwrap();
+
+    log.record(&sealed, b"pretend .ots bytes", 1_000).unwrap();
+    assert_eq!(log.pending().unwrap().len(), 1, "still pending");
+
+    log.resolve(&head(1)).unwrap();
+    assert!(log.pending().unwrap().is_empty());
+}
+
+#[test]
+fn memberships_survive_a_round_trip_to_disk() {
+    let (_d, log) = log();
+    for i in 0..7u8 {
+        log.queue(&head(i), i as i64).unwrap();
+    }
+    let sealed = log.seal().unwrap().unwrap();
+    log.record(&sealed, b"ots", 1).unwrap();
+
+    let loaded = log.members(&sealed.root).unwrap();
+    assert_eq!(loaded, sealed.members);
+    for m in &loaded {
+        assert!(sealed.verify_member(m), "proof survived serialization");
+    }
+}
+
+#[test]
+fn upgrading_replaces_the_stored_proof() {
+    let (_d, log) = log();
+    log.queue(&head(9), 1).unwrap();
+    let sealed = log.seal().unwrap().unwrap();
+
+    log.record(&sealed, b"pending proof", 1).unwrap();
+    assert_eq!(log.proof(&sealed.root).unwrap(), b"pending proof");
+
+    log.upgrade(&sealed.root, b"upgraded proof").unwrap();
+    assert_eq!(log.proof(&sealed.root).unwrap(), b"upgraded proof");
+    assert_eq!(log.batches().unwrap(), vec![sealed.root]);
+}
+
+#[test]
+fn upgrading_an_unknown_batch_is_refused() {
+    let (_d, log) = log();
+    assert!(log.upgrade(&head(0xff), b"x").is_err());
+}
+
+#[test]
+fn submission_respects_the_rate_floor() {
+    let (_d, log) = log();
+    let policy = BatchPolicy {
+        max_heads: 1,
+        max_wait_ms: 0,
+        min_interval_ms: 600_000,
+    };
+    log.queue(&head(1), 0).unwrap();
+    assert!(
+        log.should_submit(&policy, 1_000).unwrap(),
+        "nothing sent yet"
+    );
+
+    let sealed = log.seal().unwrap().unwrap();
+    log.record(&sealed, b"ots", 1_000).unwrap();
+
+    assert!(
+        !log.should_submit(&policy, 2_000).unwrap(),
+        "inside the floor"
+    );
+    assert!(log.should_submit(&policy, 601_001).unwrap());
+}
+
+/// The whole point, end to end: a leaf written locally becomes a claim a
+/// stranger can check against a Bitcoin block.
+#[test]
+fn a_local_leaf_becomes_a_verifiable_claim() {
+    use daon_provenance_core::{Beacon, BeaconChain, Ingress, Observation, RevisionLeaf};
+    use daon_provenance_verify::{verify, Claim, WitnessAttestation};
+    use daon_provenance_witness::attest::{establish_for_head, BlockHeader, BlockSource};
+    use daon_provenance_witness::ots::{Attestation, DetachedTimestamp};
+
+    struct OneBlock {
+        height: u64,
+        header: BlockHeader,
+    }
+    impl BlockSource for OneBlock {
+        fn header(&self, h: u64) -> Option<BlockHeader> {
+            (h == self.height).then_some(self.header)
+        }
+    }
+
+    // A leaf, as the agent would build one.
+    let observation = Observation {
+        tool_id: b"test-editor".to_vec(),
+        ingress: Ingress::KeystrokeStream,
+        added: 120,
+        removed: 4,
+        duration_ms: 60_000,
+        op_count: 130,
+    };
+    let leaf = RevisionLeaf {
+        seq: 0,
+        parent_head: [0u8; 32],
+        content_commit: daon_provenance_core::content_commit(b"the manuscript, at this moment"),
+        meta_commit: daon_provenance_core::meta_commit(&[observation]).unwrap(),
+        beacon: Beacon {
+            chain: BeaconChain::Bitcoin,
+            height: 800_000,
+            block_hash: [0x42; 32],
+        },
+        author_key: [0xaa; 32],
+        recovery_key: [0xbb; 32],
+        local_time_ms: 1_700_000_000_000,
+    };
+    let leaf_id = leaf.leaf_id();
+
+    // A single-leaf entity: the head is the leaf id.
+    let (_d, log) = log();
+    log.queue(&leaf_id, 1_700_000_000_000).unwrap();
+    let sealed = log.seal().unwrap().unwrap();
+
+    // A calendar timestamps the batch root; a block commits to it.
+    let mut proof = DetachedTimestamp::new(sealed.root);
+    proof
+        .timestamp
+        .attestations
+        .push(Attestation::Bitcoin { height: 810_000 });
+    log.record(&sealed, &proof.encode().unwrap(), 1_700_000_001_000)
+        .unwrap();
+
+    let chain = OneBlock {
+        height: 810_000,
+        header: BlockHeader {
+            merkle_root: sealed.root,
+            time_secs: 1_700_003_600,
+        },
+    };
+
+    // Reload from disk, exactly as a verifier would.
+    let stored = DetachedTimestamp::decode(&log.proof(&sealed.root).unwrap()).unwrap();
+    let member = log
+        .members(&sealed.root)
+        .unwrap()
+        .into_iter()
+        .find(|m| m.head == leaf_id)
+        .expect("head is in the batch");
+
+    let anchor = establish_for_head(&stored, &member, &chain).expect("anchor");
+    assert_eq!(anchor.digest, leaf_id);
+
+    let verified = verify(&Claim {
+        leaf: &leaf,
+        proof: &[],
+        head: leaf_id,
+        attestation: WitnessAttestation {
+            witnessed_head: leaf_id,
+            witness_time_ms: anchor.time_ms,
+        },
+        signature: None,
+    })
+    .expect("verifies");
+
+    assert_eq!(verified.existed_by_ms, 1_700_003_600_000);
+    assert!(!verified.author_signature_checked, "no signature supplied");
+}

--- a/provenance/witness/Cargo.toml
+++ b/provenance/witness/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "daon-provenance-witness"
+version = "0.0.0"          # not published; the wire format is not frozen yet
+description = "OpenTimestamps proofs and head batching for DAON provenance"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+daon-provenance-core.workspace = true
+sha2.workspace = true
+ripemd = "0.1"
+
+[dev-dependencies]
+hex.workspace = true
+sha2.workspace = true
+
+[features]
+default = ["std"]
+std = ["daon-provenance-core/std"]

--- a/provenance/witness/src/attest.rs
+++ b/provenance/witness/src/attest.rs
@@ -1,0 +1,197 @@
+//! Turning an OpenTimestamps proof into something the verifier accepts.
+//!
+//! [`crate::ots`] can replay a proof and say "this path ends in a Bitcoin
+//! attestation at height N, having computed digest D". That is not yet
+//! evidence. Two things are still missing, and neither can be invented locally:
+//!
+//! 1. **What is actually in block N.** The attestation claims D is that block's
+//!    merkle root. Believing it without checking would accept any proof at all.
+//! 2. **When block N happened.** The witness time is the block's timestamp, and
+//!    only a Bitcoin header carries it.
+//!
+//! Both come from a [`BlockSource`], which this crate does not implement. No
+//! socket is opened here. An agent supplies a source backed by whatever it
+//! trusts — a full node, an Electrum server, a header chain it has validated —
+//! and that choice is deliberately the caller's, because it decides what the
+//! whole proof rests on.
+
+use alloc::vec::Vec;
+use daon_provenance_core::Hash;
+
+use crate::batch::BatchMembership;
+use crate::ots::{Attestation, DetachedTimestamp, Error as OtsError};
+
+/// The parts of a Bitcoin block header this needs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockHeader {
+    /// The block's merkle root, as it appears in the header.
+    pub merkle_root: [u8; 32],
+    /// The header's `nTime`, in **seconds**.
+    ///
+    /// Bitcoin block times are not exact. A miner may set `nTime` ahead of real
+    /// time, bounded by consensus to roughly two hours, and it need only exceed
+    /// the median of the previous eleven blocks. So this is an *approximate
+    /// upper bound* on when the data existed, which is exactly the claim the
+    /// system makes -- and why nothing here should be presented as a precise
+    /// moment.
+    pub time_secs: u32,
+}
+
+/// Where block headers come from.
+///
+/// Implementations decide their own trust model. A verifier with a full node
+/// answers from consensus; one with a header chain answers from proof-of-work;
+/// one asking a remote API is trusting that API, and should say so to whoever
+/// reads the result.
+pub trait BlockSource {
+    /// The header at `height`, or `None` if unknown or not yet reached.
+    fn header(&self, height: u64) -> Option<BlockHeader>;
+}
+
+/// Why an attestation could not be established.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    /// The proof did not parse or an operation could not be replayed.
+    Ots(OtsError),
+    /// The proof carries no Bitcoin attestation. Usually means it is still
+    /// pending at a calendar and has not been upgraded -- see
+    /// [`needs_upgrade`].
+    NoBitcoinAttestation,
+    /// The block source does not know this height.
+    UnknownBlock { height: u64 },
+    /// The proof's computed digest is not that block's merkle root.
+    ///
+    /// The proof is claiming something Bitcoin does not say.
+    MerkleRootMismatch {
+        height: u64,
+        claimed: [u8; 32],
+        actual: [u8; 32],
+    },
+    /// A batch membership does not lead to the timestamped root.
+    NotInBatch,
+}
+
+impl From<OtsError> for Error {
+    fn from(e: OtsError) -> Self {
+        Error::Ots(e)
+    }
+}
+
+/// An established Bitcoin anchor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Anchor {
+    /// The digest Bitcoin committed to.
+    pub digest: Hash,
+    /// The block it was committed in.
+    pub height: u64,
+    /// The block header's time, in milliseconds, for the verifier's
+    /// `witness_time_ms`.
+    pub time_ms: i64,
+}
+
+/// Whether this proof still needs upgrading before it proves anything.
+///
+/// A freshly submitted proof comes back **pending**: the calendar has the digest
+/// but has not yet included it in a Bitcoin transaction. It is a receipt, not a
+/// timestamp. The agent must come back later and replace it with the upgraded
+/// proof, and until it does, the head is not witnessed.
+///
+/// This is the step most easily forgotten, because a pending proof is a
+/// perfectly valid file that parses cleanly and looks finished.
+pub fn needs_upgrade(proof: &DetachedTimestamp) -> Result<bool, Error> {
+    let attestations = proof.attestations()?;
+    let has_bitcoin = attestations
+        .iter()
+        .any(|(a, _)| matches!(a, Attestation::Bitcoin { .. }));
+    Ok(!has_bitcoin)
+}
+
+/// Every calendar URI this proof is still waiting on.
+pub fn pending_calendars(proof: &DetachedTimestamp) -> Result<Vec<Vec<u8>>, Error> {
+    Ok(proof
+        .attestations()?
+        .into_iter()
+        .filter_map(|(a, _)| match a {
+            Attestation::Pending { uri } => Some(uri),
+            _ => None,
+        })
+        .collect())
+}
+
+/// Establish the earliest Bitcoin anchor in a proof.
+///
+/// Every Bitcoin attestation is checked against the block source and the
+/// **earliest surviving one wins**, because the claim is "this existed no later
+/// than T" and a later anchor is a weaker version of the same fact.
+///
+/// An attestation whose digest does not match its block is not merely skipped —
+/// it is reported. A proof that lies about one block should not quietly pass on
+/// the strength of another.
+pub fn establish<S: BlockSource>(proof: &DetachedTimestamp, source: &S) -> Result<Anchor, Error> {
+    let mut best: Option<Anchor> = None;
+
+    for (attestation, digest) in proof.attestations()? {
+        let Attestation::Bitcoin { height } = attestation else {
+            continue;
+        };
+        let header = source
+            .header(height)
+            .ok_or(Error::UnknownBlock { height })?;
+
+        // OTS computes the merkle root in Bitcoin's internal byte order, which
+        // is the reverse of how block explorers display it. Compare in the
+        // internal order and let callers do their own presentation.
+        let claimed: [u8; 32] = digest
+            .as_slice()
+            .try_into()
+            .map_err(|_| Error::Ots(OtsError::DigestLength))?;
+
+        if claimed != header.merkle_root {
+            return Err(Error::MerkleRootMismatch {
+                height,
+                claimed,
+                actual: header.merkle_root,
+            });
+        }
+
+        let anchor = Anchor {
+            digest: proof_digest(proof)?,
+            height,
+            time_ms: header.time_secs as i64 * 1000,
+        };
+        if best.is_none_or(|b| anchor.time_ms < b.time_ms) {
+            best = Some(anchor);
+        }
+    }
+
+    best.ok_or(Error::NoBitcoinAttestation)
+}
+
+fn proof_digest(proof: &DetachedTimestamp) -> Result<Hash, Error> {
+    proof
+        .digest
+        .as_slice()
+        .try_into()
+        .map_err(|_| Error::Ots(OtsError::DigestLength))
+}
+
+/// Establish the anchor for a single head inside a batch.
+///
+/// The proof timestamps the batch **root**, not the head. This checks that the
+/// head really is in that batch before returning the anchor, so a membership
+/// belonging to some other batch cannot borrow this one's timestamp.
+pub fn establish_for_head<S: BlockSource>(
+    proof: &DetachedTimestamp,
+    member: &BatchMembership,
+    source: &S,
+) -> Result<Anchor, Error> {
+    let root = proof_digest(proof)?;
+    if !daon_provenance_core::verify_inclusion(&member.head, &member.proof, &root) {
+        return Err(Error::NotInBatch);
+    }
+    let anchor = establish(proof, source)?;
+    Ok(Anchor {
+        digest: member.head,
+        ..anchor
+    })
+}

--- a/provenance/witness/src/batch.rs
+++ b/provenance/witness/src/batch.rs
@@ -1,0 +1,183 @@
+//! Batching heads into a single witness.
+//!
+//! # Why this is mandatory rather than an optimisation
+//!
+//! Witnessing is the one operation in this system that consumes a shared,
+//! finite resource: calendar servers run on somebody else's goodwill, and every
+//! Bitcoin anchor costs a real fee someone pays. Authoring events are free and
+//! local, leaves are free and local, **witnesses are neither**.
+//!
+//! So the agent must never submit one head per save. It accumulates heads, and
+//! submits a single digest covering all of them.
+//!
+//! # The trick is that we already have the machinery
+//!
+//! A batch is a Merkle tree over the pending heads, and the batch root is what
+//! gets timestamped. Each head then keeps an inclusion proof against that root —
+//! and `daon-provenance-core` already computes exactly these, because it is the
+//! same construction the revision log uses.
+//!
+//! One anchor therefore witnesses any number of heads at the cost of
+//! `log2(n)` extra hashes each, and verification stays the four steps: a batch
+//! adds a hop to the proof, never a new kind of check.
+
+use alloc::vec::Vec;
+use daon_provenance_core::{inclusion_proof, merkle_root, verify_inclusion, Hash, ProofStep};
+
+/// Heads waiting to be witnessed together.
+#[derive(Debug, Clone, Default)]
+pub struct Batch {
+    heads: Vec<Hash>,
+}
+
+/// A head's place in a sealed batch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatchMembership {
+    /// The head this is about.
+    pub head: Hash,
+    /// Its position in the batch.
+    pub index: usize,
+    /// Path from the head to the batch root.
+    pub proof: Vec<ProofStep>,
+}
+
+/// A batch that has been closed and is ready to submit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SealedBatch {
+    /// The digest to hand to a calendar. **This** is what gets timestamped.
+    pub root: Hash,
+    /// One entry per head, in batch order.
+    pub members: Vec<BatchMembership>,
+}
+
+impl Batch {
+    /// An empty batch.
+    pub fn new() -> Self {
+        Batch::default()
+    }
+
+    /// How many heads are waiting.
+    pub fn len(&self) -> usize {
+        self.heads.len()
+    }
+
+    /// Whether nothing is waiting.
+    pub fn is_empty(&self) -> bool {
+        self.heads.is_empty()
+    }
+
+    /// Queue a head.
+    ///
+    /// Duplicates are dropped. The same head arriving twice is the ordinary
+    /// result of an idle agent re-checking its log, and submitting it twice
+    /// would spend a shared resource to prove something already proven.
+    pub fn push(&mut self, head: Hash) -> bool {
+        if self.heads.contains(&head) {
+            return false;
+        }
+        self.heads.push(head);
+        true
+    }
+
+    /// Close the batch and compute the digest to submit.
+    ///
+    /// Returns `None` for an empty batch: there is nothing to witness, and
+    /// submitting the Merkle root of nothing would burn a request to prove that
+    /// no work happened.
+    pub fn seal(&self) -> Option<SealedBatch> {
+        if self.heads.is_empty() {
+            return None;
+        }
+        let root = merkle_root(&self.heads);
+        let members = self
+            .heads
+            .iter()
+            .enumerate()
+            .map(|(index, head)| BatchMembership {
+                head: *head,
+                index,
+                proof: inclusion_proof(&self.heads, index),
+            })
+            .collect();
+        Some(SealedBatch { root, members })
+    }
+}
+
+impl SealedBatch {
+    /// Check that a membership really leads to this batch's root.
+    ///
+    /// Worth calling before persisting. A membership that does not verify is a
+    /// bug that would otherwise surface years later, when someone tried to use
+    /// the proof and found it worthless.
+    pub fn verify_member(&self, member: &BatchMembership) -> bool {
+        verify_inclusion(&member.head, &member.proof, &self.root)
+    }
+}
+
+/// When a batch should be sealed and submitted.
+///
+/// Both limits are ceilings, not targets. Reaching either seals the batch; the
+/// interval exists so a slow writer is not left unwitnessed indefinitely, and
+/// the size cap exists so a fast one does not build a proof so wide that every
+/// member pays for it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BatchPolicy {
+    /// Seal once this many heads are waiting.
+    pub max_heads: usize,
+    /// Seal once the oldest head has waited this long.
+    pub max_wait_ms: i64,
+    /// Never submit more often than this, whatever else is true.
+    ///
+    /// The backstop. Every other rule here can be argued with; this one is what
+    /// stops a misbehaving caller from becoming a problem for the calendars.
+    pub min_interval_ms: i64,
+}
+
+impl Default for BatchPolicy {
+    fn default() -> Self {
+        BatchPolicy {
+            // 512 heads is a 9-deep proof: negligible per member, and far more
+            // than a single creator generates between anchors.
+            max_heads: 512,
+            // An hour bounds how stale an unwitnessed head can be. Bitcoin's own
+            // granularity is ~10 minutes, so finer would buy nothing real.
+            max_wait_ms: 60 * 60 * 1000,
+            // Ten minutes. One Bitcoin block; submitting faster cannot produce a
+            // better timestamp, so it would be pure waste.
+            min_interval_ms: 10 * 60 * 1000,
+        }
+    }
+}
+
+impl BatchPolicy {
+    /// Whether to seal and submit now.
+    ///
+    /// `now_ms` and the timestamps are the agent's local clock, which is
+    /// untrusted for evidence but perfectly fine for deciding when to make a
+    /// request. The witness time comes from Bitcoin, not from here.
+    pub fn should_submit(
+        &self,
+        batch: &Batch,
+        oldest_head_ms: Option<i64>,
+        last_submit_ms: Option<i64>,
+        now_ms: i64,
+    ) -> bool {
+        if batch.is_empty() {
+            return false;
+        }
+        // The floor is checked first and overrides everything, so no combination
+        // of the rules below can produce a burst.
+        if let Some(last) = last_submit_ms {
+            if now_ms.saturating_sub(last) < self.min_interval_ms {
+                return false;
+            }
+        }
+        if batch.len() >= self.max_heads {
+            return true;
+        }
+        match oldest_head_ms {
+            Some(oldest) => now_ms.saturating_sub(oldest) >= self.max_wait_ms,
+            None => false,
+        }
+    }
+}

--- a/provenance/witness/src/lib.rs
+++ b/provenance/witness/src/lib.rs
@@ -1,0 +1,57 @@
+//! Witnessing for DAON provenance — the step that makes a local log evidence.
+//!
+//! Everything else in `provenance/` is local and free. An agent can hash, chain
+//! and sign revisions all day without asking anyone's permission, and none of it
+//! proves *when*. This crate is where a head stops being a private assertion and
+//! becomes something a stranger can check against Bitcoin.
+//!
+//! # What is here
+//!
+//! - [`ots`] — the OpenTimestamps detached-proof format: parse, serialize,
+//!   replay operations, read attestations.
+//! - [`batch`] — many heads under one anchor, via the Merkle machinery the
+//!   revision log already uses.
+//! - [`attest`] — turning a proof plus a Bitcoin header into the
+//!   `WitnessAttestation` the verifier consumes.
+//!
+//! # What is deliberately not here
+//!
+//! **No network.** This crate opens no socket, resolves no hostname and trusts
+//! no server. Submitting a digest to a calendar and fetching Bitcoin headers are
+//! the caller's job, behind [`attest::BlockSource`] and whatever transport it
+//! chooses.
+//!
+//! That is not squeamishness about dependencies. Whoever supplies the block
+//! headers decides what the entire proof rests on — a full node means consensus,
+//! a remote API means trusting that API — and burying that choice inside a
+//! library would hide the most important assumption in the system. It stays in
+//! the open, at the call site.
+//!
+//! **No clock.** Witness time comes from a Bitcoin block header. The agent's own
+//! clock is used only to decide when to make a request, never as evidence.
+//!
+//! # The shape of a witnessed head
+//!
+//! ```text
+//!   heads ──► Batch ──► seal ──► root ──► calendar ──► pending proof
+//!                                                            │
+//!                                            (wait for a block, then upgrade)
+//!                                                            ▼
+//!   verify ◄── Anchor ◄── establish_for_head ◄────────  Bitcoin proof
+//! ```
+//!
+//! The pending stage is the one that gets forgotten: a freshly submitted proof
+//! parses cleanly, looks complete, and proves nothing. See
+//! [`attest::needs_upgrade`].
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+pub mod attest;
+pub mod batch;
+pub mod ots;
+
+pub use attest::{Anchor, BlockHeader, BlockSource};
+pub use batch::{Batch, BatchMembership, BatchPolicy, SealedBatch};
+pub use ots::{Attestation, DetachedTimestamp, Timestamp};

--- a/provenance/witness/src/ots.rs
+++ b/provenance/witness/src/ots.rs
@@ -1,0 +1,468 @@
+//! The OpenTimestamps detached-proof format.
+//!
+//! A `.ots` file is a digest plus a **tree of operations**. Each path through
+//! the tree transforms the digest step by step and ends at an *attestation* —
+//! either "a calendar has this, come back later" or "this is committed in
+//! Bitcoin block N".
+//!
+//! Verification is therefore: replay the operations, and see what the result is
+//! claimed to be. This module does the replaying and the parsing. It resolves
+//! nothing against Bitcoin — [`crate::attest`] does that, because it needs a
+//! source of block headers and this module deliberately has none.
+//!
+//! Reference: <https://github.com/opentimestamps/python-opentimestamps>
+
+use alloc::vec::Vec;
+use daon_provenance_core::Hash;
+
+/// The 31-byte header every detached proof starts with.
+pub const MAGIC: &[u8] = b"\x00OpenTimestamps\x00\x00Proof\x00\xbf\x89\xe2\xe8\x84\xe8\x92\x94";
+
+/// Serialization format version. Only 1 exists.
+pub const VERSION: u8 = 1;
+
+const OP_SHA1: u8 = 0x02;
+const OP_RIPEMD160: u8 = 0x03;
+const OP_SHA256: u8 = 0x08;
+const OP_APPEND: u8 = 0xf0;
+const OP_PREPEND: u8 = 0xf1;
+const OP_REVERSE: u8 = 0xf2;
+const OP_HEXLIFY: u8 = 0xf3;
+
+const TAG_ATTESTATION: u8 = 0x00;
+const TAG_FORK: u8 = 0xff;
+
+const ATTEST_BITCOIN: [u8; 8] = [0x05, 0x88, 0x96, 0x0d, 0x73, 0xd7, 0x19, 0x01];
+const ATTEST_PENDING: [u8; 8] = [0x83, 0xdf, 0xe3, 0x0d, 0x2e, 0xf9, 0x0c, 0x8e];
+
+/// Guards against a hostile proof allocating unbounded memory. The real format
+/// never needs anything close to this; OTS itself uses the same limit.
+const MAX_VARBYTES: u64 = 4096;
+
+/// A malformed or unsupported proof.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    /// Not an OpenTimestamps detached proof.
+    BadMagic,
+    /// Serialization version this code does not implement.
+    UnsupportedVersion(u8),
+    /// Ran out of bytes mid-structure.
+    Truncated,
+    /// A length prefix exceeded [`MAX_VARBYTES`], or a varint did not terminate.
+    LengthOutOfRange,
+    /// An operation tag this code does not implement.
+    UnknownOp(u8),
+    /// Bytes remain after the proof ends. Refused rather than ignored: trailing
+    /// data means the file is not what it claims, and a lenient parser here
+    /// would let two implementations disagree about the same file.
+    TrailingBytes,
+    /// The file's digest is not the length its hash op requires.
+    DigestLength,
+    /// A node has neither attestations nor branches, so it cannot be written in
+    /// a form any reader could terminate.
+    EmptyTimestamp,
+}
+
+/// One step in a proof path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Op {
+    /// Concatenate the argument onto the end.
+    Append(Vec<u8>),
+    /// Concatenate the argument onto the front.
+    Prepend(Vec<u8>),
+    /// Reverse the bytes. Deprecated upstream; parsed so old proofs still read.
+    Reverse,
+    /// Lowercase hex encoding.
+    Hexlify,
+    /// Hash with SHA-1. **Broken**; see [`Op::execute`].
+    Sha1,
+    /// Hash with RIPEMD-160.
+    Ripemd160,
+    /// Hash with SHA-256.
+    Sha256,
+}
+
+impl Op {
+    /// Apply this operation to a message.
+    ///
+    /// SHA-1 is implemented as an error rather than computed. Collisions have
+    /// been public since 2017, so a proof whose path runs through SHA-1 can be
+    /// forged, and quietly honouring one would let a forgery verify. Old proofs
+    /// that use it are rejected, not upgraded.
+    pub fn execute(&self, msg: &[u8]) -> Result<Vec<u8>, Error> {
+        use sha2::{Digest, Sha256};
+        Ok(match self {
+            Op::Append(arg) => [msg, arg].concat(),
+            Op::Prepend(arg) => [arg.as_slice(), msg].concat(),
+            Op::Reverse => msg.iter().rev().copied().collect(),
+            Op::Hexlify => {
+                let mut out = Vec::with_capacity(msg.len() * 2);
+                for b in msg {
+                    out.push(hex_nibble(b >> 4));
+                    out.push(hex_nibble(b & 0x0f));
+                }
+                out
+            }
+            Op::Sha1 => return Err(Error::UnknownOp(OP_SHA1)),
+            Op::Ripemd160 => {
+                use ripemd::Ripemd160;
+                Ripemd160::digest(msg).to_vec()
+            }
+            Op::Sha256 => Sha256::digest(msg).to_vec(),
+        })
+    }
+}
+
+fn hex_nibble(n: u8) -> u8 {
+    if n < 10 {
+        b'0' + n
+    } else {
+        b'a' + (n - 10)
+    }
+}
+
+/// What a proof path terminates in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Attestation {
+    /// Committed in the merkle root of a Bitcoin block.
+    Bitcoin { height: u64 },
+    /// A calendar holds this and will have a Bitcoin attestation later. A proof
+    /// with only pending attestations proves **nothing** about time yet.
+    Pending { uri: Vec<u8> },
+    /// A tag this code does not recognise. Kept rather than dropped so
+    /// re-serialization round-trips, but never treated as evidence.
+    Unknown { tag: [u8; 8], payload: Vec<u8> },
+}
+
+/// A timestamp tree: operations leading to attestations, possibly branching.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Timestamp {
+    /// Attestations on the digest at this node.
+    pub attestations: Vec<Attestation>,
+    /// Each branch applies an operation, then continues.
+    pub ops: Vec<(Op, Timestamp)>,
+}
+
+impl Timestamp {
+    /// Whether this node carries nothing at all. Such a node is not
+    /// serializable -- see [`DetachedTimestamp::encode`].
+    pub fn is_empty(&self) -> bool {
+        self.attestations.is_empty() && self.ops.is_empty()
+    }
+}
+
+/// A parsed `.ots` detached proof.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DetachedTimestamp {
+    /// The op identifying how the file digest was produced (always SHA-256 for
+    /// our use, but the format permits others).
+    pub file_hash_op: Op,
+    /// The digest being timestamped.
+    pub digest: Vec<u8>,
+    /// The tree rooted at that digest.
+    pub timestamp: Timestamp,
+}
+
+impl DetachedTimestamp {
+    /// Build a proof over a 32-byte digest, with no attestations yet.
+    pub fn new(digest: Hash) -> Self {
+        DetachedTimestamp {
+            file_hash_op: Op::Sha256,
+            digest: digest.to_vec(),
+            timestamp: Timestamp::default(),
+        }
+    }
+
+    /// Parse a `.ots` file.
+    pub fn decode(bytes: &[u8]) -> Result<Self, Error> {
+        let mut c = Cursor::new(bytes);
+        if c.take(MAGIC.len())? != MAGIC {
+            return Err(Error::BadMagic);
+        }
+        let version = c.varint()?;
+        if version != VERSION as u64 {
+            return Err(Error::UnsupportedVersion(version as u8));
+        }
+        let file_hash_op = c.hash_op()?;
+        let digest_len = hash_op_len(&file_hash_op);
+        let digest = c.take(digest_len)?.to_vec();
+        let timestamp = c.timestamp()?;
+        if !c.is_empty() {
+            return Err(Error::TrailingBytes);
+        }
+        Ok(DetachedTimestamp {
+            file_hash_op,
+            digest,
+            timestamp,
+        })
+    }
+
+    /// Serialize back to `.ots` bytes.
+    ///
+    /// Refuses a tree with no items. A node is terminated by the *absence* of a
+    /// fork marker before its final item, so an empty one has no terminator and
+    /// writing it would produce a file nothing can parse -- including us.
+    pub fn encode(&self) -> Result<Vec<u8>, Error> {
+        if self.digest.len() != hash_op_len(&self.file_hash_op) {
+            return Err(Error::DigestLength);
+        }
+        if self.timestamp.is_empty() {
+            return Err(Error::EmptyTimestamp);
+        }
+        let mut out = Vec::from(MAGIC);
+        put_varint(&mut out, VERSION as u64);
+        out.push(hash_op_tag(&self.file_hash_op));
+        out.extend_from_slice(&self.digest);
+        put_timestamp(&mut out, &self.timestamp);
+        Ok(out)
+    }
+
+    /// Every attestation in the tree, paired with the digest it attests to.
+    ///
+    /// The digest is what the path *computes*, which is the only thing that can
+    /// be checked against a block's merkle root. An attestation considered
+    /// without its computed digest says nothing.
+    pub fn attestations(&self) -> Result<Vec<(Attestation, Vec<u8>)>, Error> {
+        let mut found = Vec::new();
+        walk(&self.timestamp, &self.digest, &mut found)?;
+        Ok(found)
+    }
+}
+
+fn walk(ts: &Timestamp, msg: &[u8], out: &mut Vec<(Attestation, Vec<u8>)>) -> Result<(), Error> {
+    for a in &ts.attestations {
+        out.push((a.clone(), msg.to_vec()));
+    }
+    for (op, next) in &ts.ops {
+        let stepped = op.execute(msg)?;
+        walk(next, &stepped, out)?;
+    }
+    Ok(())
+}
+
+fn hash_op_len(op: &Op) -> usize {
+    match op {
+        Op::Sha1 | Op::Ripemd160 => 20,
+        _ => 32,
+    }
+}
+
+fn hash_op_tag(op: &Op) -> u8 {
+    match op {
+        Op::Sha1 => OP_SHA1,
+        Op::Ripemd160 => OP_RIPEMD160,
+        _ => OP_SHA256,
+    }
+}
+
+// ── decoding ──────────────────────────────────────────────────────────────
+
+struct Cursor<'a> {
+    b: &'a [u8],
+    i: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(b: &'a [u8]) -> Self {
+        Cursor { b, i: 0 }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.i >= self.b.len()
+    }
+
+    fn byte(&mut self) -> Result<u8, Error> {
+        let v = *self.b.get(self.i).ok_or(Error::Truncated)?;
+        self.i += 1;
+        Ok(v)
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], Error> {
+        let end = self.i.checked_add(n).ok_or(Error::LengthOutOfRange)?;
+        let s = self.b.get(self.i..end).ok_or(Error::Truncated)?;
+        self.i = end;
+        Ok(s)
+    }
+
+    /// Base-128 varint, little-endian groups, high bit as continuation.
+    fn varint(&mut self) -> Result<u64, Error> {
+        let mut value: u64 = 0;
+        let mut shift = 0u32;
+        loop {
+            let b = self.byte()?;
+            let part = (b & 0x7f) as u64;
+            // Reject shifts that would silently drop bits rather than wrapping
+            // into a different number than the writer meant.
+            if shift >= 64 || (part << shift) >> shift != part {
+                return Err(Error::LengthOutOfRange);
+            }
+            value |= part << shift;
+            if b & 0x80 == 0 {
+                return Ok(value);
+            }
+            shift += 7;
+        }
+    }
+
+    fn varbytes(&mut self) -> Result<Vec<u8>, Error> {
+        let n = self.varint()?;
+        if n > MAX_VARBYTES {
+            return Err(Error::LengthOutOfRange);
+        }
+        Ok(self.take(n as usize)?.to_vec())
+    }
+
+    fn hash_op(&mut self) -> Result<Op, Error> {
+        match self.byte()? {
+            OP_SHA1 => Ok(Op::Sha1),
+            OP_RIPEMD160 => Ok(Op::Ripemd160),
+            OP_SHA256 => Ok(Op::Sha256),
+            other => Err(Error::UnknownOp(other)),
+        }
+    }
+
+    /// A node is a list of items -- attestations and operation branches --
+    /// where every item **except the last** is preceded by `0xff`. The absence
+    /// of that marker is the only thing that terminates a node, which is why
+    /// the last item is read outside the loop.
+    fn timestamp(&mut self) -> Result<Timestamp, Error> {
+        let mut ts = Timestamp::default();
+        let mut tag = self.byte()?;
+        while tag == TAG_FORK {
+            let inner = self.byte()?;
+            self.item(&mut ts, inner)?;
+            tag = self.byte()?;
+        }
+        self.item(&mut ts, tag)?;
+        Ok(ts)
+    }
+
+    /// One item: an attestation, or an operation and everything below it.
+    fn item(&mut self, ts: &mut Timestamp, tag: u8) -> Result<(), Error> {
+        if tag == TAG_ATTESTATION {
+            ts.attestations.push(self.attestation()?);
+        } else {
+            let op = self.op_from(tag)?;
+            let sub = self.timestamp()?;
+            ts.ops.push((op, sub));
+        }
+        Ok(())
+    }
+
+    fn op_from(&mut self, tag: u8) -> Result<Op, Error> {
+        Ok(match tag {
+            OP_APPEND => Op::Append(self.varbytes()?),
+            OP_PREPEND => Op::Prepend(self.varbytes()?),
+            OP_REVERSE => Op::Reverse,
+            OP_HEXLIFY => Op::Hexlify,
+            OP_SHA1 => Op::Sha1,
+            OP_RIPEMD160 => Op::Ripemd160,
+            OP_SHA256 => Op::Sha256,
+            other => return Err(Error::UnknownOp(other)),
+        })
+    }
+
+    fn attestation(&mut self) -> Result<Attestation, Error> {
+        let mut tag = [0u8; 8];
+        tag.copy_from_slice(self.take(8)?);
+        // The payload is length-prefixed so an unknown attestation type can be
+        // skipped rather than making the whole proof unreadable.
+        let payload = self.varbytes()?;
+        Ok(match tag {
+            ATTEST_BITCOIN => {
+                let mut inner = Cursor::new(&payload);
+                Attestation::Bitcoin {
+                    height: inner.varint()?,
+                }
+            }
+            ATTEST_PENDING => {
+                let mut inner = Cursor::new(&payload);
+                Attestation::Pending {
+                    uri: inner.varbytes()?,
+                }
+            }
+            _ => Attestation::Unknown { tag, payload },
+        })
+    }
+}
+
+// ── encoding ──────────────────────────────────────────────────────────────
+
+fn put_varint(out: &mut Vec<u8>, mut v: u64) {
+    loop {
+        let mut b = (v & 0x7f) as u8;
+        v >>= 7;
+        if v != 0 {
+            b |= 0x80;
+        }
+        out.push(b);
+        if v == 0 {
+            return;
+        }
+    }
+}
+
+fn put_varbytes(out: &mut Vec<u8>, b: &[u8]) {
+    put_varint(out, b.len() as u64);
+    out.extend_from_slice(b);
+}
+
+fn put_op(out: &mut Vec<u8>, op: &Op) {
+    match op {
+        Op::Append(a) => {
+            out.push(OP_APPEND);
+            put_varbytes(out, a);
+        }
+        Op::Prepend(a) => {
+            out.push(OP_PREPEND);
+            put_varbytes(out, a);
+        }
+        Op::Reverse => out.push(OP_REVERSE),
+        Op::Hexlify => out.push(OP_HEXLIFY),
+        Op::Sha1 => out.push(OP_SHA1),
+        Op::Ripemd160 => out.push(OP_RIPEMD160),
+        Op::Sha256 => out.push(OP_SHA256),
+    }
+}
+
+/// Mirror of [`Cursor::timestamp`]: attestations first, then op branches, with
+/// `0xff` before every item but the last.
+fn put_timestamp(out: &mut Vec<u8>, ts: &Timestamp) {
+    let total = ts.attestations.len() + ts.ops.len();
+    let mut written = 0usize;
+    let sep = |out: &mut Vec<u8>, written: usize| {
+        if written + 1 < total {
+            out.push(TAG_FORK);
+        }
+    };
+
+    for a in &ts.attestations {
+        sep(out, written);
+        written += 1;
+        out.push(TAG_ATTESTATION);
+        match a {
+            Attestation::Bitcoin { height } => {
+                out.extend_from_slice(&ATTEST_BITCOIN);
+                let mut payload = Vec::new();
+                put_varint(&mut payload, *height);
+                put_varbytes(out, &payload);
+            }
+            Attestation::Pending { uri } => {
+                out.extend_from_slice(&ATTEST_PENDING);
+                let mut payload = Vec::new();
+                put_varbytes(&mut payload, uri);
+                put_varbytes(out, &payload);
+            }
+            Attestation::Unknown { tag, payload } => {
+                out.extend_from_slice(tag);
+                put_varbytes(out, payload);
+            }
+        }
+    }
+    for (op, sub) in &ts.ops {
+        sep(out, written);
+        written += 1;
+        put_op(out, op);
+        put_timestamp(out, sub);
+    }
+}

--- a/provenance/witness/tests/attest.rs
+++ b/provenance/witness/tests/attest.rs
@@ -1,0 +1,184 @@
+//! Establishing a Bitcoin anchor — the checks a forged proof has to get past.
+
+use daon_provenance_witness::attest::{establish, establish_for_head, needs_upgrade, Error};
+use daon_provenance_witness::batch::Batch;
+use daon_provenance_witness::ots::{Attestation, DetachedTimestamp, Op, Timestamp};
+use daon_provenance_witness::{BlockHeader, BlockSource};
+use std::collections::HashMap;
+
+/// A block source that knows exactly what it is told and nothing else.
+#[derive(Default)]
+struct Chain(HashMap<u64, BlockHeader>);
+
+impl Chain {
+    fn with(mut self, height: u64, merkle_root: [u8; 32], time_secs: u32) -> Self {
+        self.0.insert(
+            height,
+            BlockHeader {
+                merkle_root,
+                time_secs,
+            },
+        );
+        self
+    }
+}
+
+impl BlockSource for Chain {
+    fn header(&self, height: u64) -> Option<BlockHeader> {
+        self.0.get(&height).copied()
+    }
+}
+
+/// A proof that attests `digest` directly, with no intervening operations, so
+/// the digest the path computes is the digest itself.
+fn direct(digest: [u8; 32], height: u64) -> DetachedTimestamp {
+    let mut p = DetachedTimestamp::new(digest);
+    p.timestamp
+        .attestations
+        .push(Attestation::Bitcoin { height });
+    p
+}
+
+#[test]
+fn establishes_an_anchor_from_a_matching_block() {
+    let d = [0xab; 32];
+    let chain = Chain::default().with(800_000, d, 1_700_000_000);
+    let anchor = establish(&direct(d, 800_000), &chain).expect("anchor");
+
+    assert_eq!(anchor.height, 800_000);
+    assert_eq!(anchor.digest, d);
+    assert_eq!(anchor.time_ms, 1_700_000_000_000, "seconds to milliseconds");
+}
+
+/// The check that matters most: a proof claiming a digest Bitcoin does not have
+/// must fail, not fall through to some other attestation.
+#[test]
+fn refuses_a_digest_the_block_does_not_commit_to() {
+    let chain = Chain::default().with(800_000, [0x11; 32], 1_700_000_000);
+    match establish(&direct([0xab; 32], 800_000), &chain) {
+        Err(Error::MerkleRootMismatch { height, .. }) => assert_eq!(height, 800_000),
+        other => panic!("expected a mismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn refuses_a_block_the_source_does_not_know() {
+    let chain = Chain::default();
+    assert_eq!(
+        establish(&direct([0xab; 32], 999_999), &chain),
+        Err(Error::UnknownBlock { height: 999_999 })
+    );
+}
+
+/// A pending proof parses cleanly and looks finished. It proves nothing.
+#[test]
+fn a_pending_proof_is_not_an_anchor() {
+    let mut p = DetachedTimestamp::new([0xcd; 32]);
+    p.timestamp.attestations.push(Attestation::Pending {
+        uri: b"https://a.pool.opentimestamps.org".to_vec(),
+    });
+
+    assert!(needs_upgrade(&p).unwrap(), "pending must need upgrading");
+    assert_eq!(
+        establish(&p, &Chain::default()),
+        Err(Error::NoBitcoinAttestation)
+    );
+}
+
+#[test]
+fn a_bitcoin_proof_does_not_need_upgrading() {
+    assert!(!needs_upgrade(&direct([1; 32], 5)).unwrap());
+}
+
+/// "Existed no later than T" means the earliest anchor is the strongest claim.
+#[test]
+fn the_earliest_anchor_wins() {
+    let d = [0x77; 32];
+    let mut p = DetachedTimestamp::new(d);
+    p.timestamp
+        .attestations
+        .push(Attestation::Bitcoin { height: 800_000 });
+    p.timestamp
+        .attestations
+        .push(Attestation::Bitcoin { height: 700_000 });
+
+    let chain = Chain::default()
+        .with(800_000, d, 1_700_000_000)
+        .with(700_000, d, 1_600_000_000);
+
+    let anchor = establish(&p, &chain).unwrap();
+    assert_eq!(anchor.height, 700_000);
+    assert_eq!(anchor.time_ms, 1_600_000_000_000);
+}
+
+/// One anchor, many heads: the proof timestamps the batch root, and each head
+/// reaches it through its inclusion proof.
+#[test]
+fn a_batched_head_inherits_the_batch_anchor() {
+    let mut batch = Batch::new();
+    for i in 0..5u8 {
+        batch.push([i; 32]);
+    }
+    let sealed = batch.seal().unwrap();
+
+    let chain = Chain::default().with(810_000, sealed.root, 1_710_000_000);
+    let proof = direct(sealed.root, 810_000);
+
+    for member in &sealed.members {
+        let anchor = establish_for_head(&proof, member, &chain).expect("anchor");
+        assert_eq!(anchor.digest, member.head, "anchor names the head");
+        assert_eq!(anchor.time_ms, 1_710_000_000_000);
+    }
+}
+
+/// A membership from a different batch must not borrow this anchor.
+#[test]
+fn a_foreign_membership_is_refused() {
+    let mut a = Batch::new();
+    for i in 0..4u8 {
+        a.push([i; 32]);
+    }
+    let mut b = Batch::new();
+    for i in 20..24u8 {
+        b.push([i; 32]);
+    }
+    let (sa, sb) = (a.seal().unwrap(), b.seal().unwrap());
+
+    let chain = Chain::default().with(1, sa.root, 1_000);
+    let proof = direct(sa.root, 1);
+
+    assert_eq!(
+        establish_for_head(&proof, &sb.members[0], &chain),
+        Err(Error::NotInBatch)
+    );
+}
+
+/// Operations must actually be replayed: the attested digest is what the path
+/// computes, not the file digest.
+#[test]
+fn the_attested_digest_is_the_computed_one() {
+    use sha2::{Digest, Sha256};
+
+    let file = [0x5a; 32];
+    let computed: [u8; 32] = Sha256::digest(file).into();
+
+    let mut p = DetachedTimestamp::new(file);
+    p.timestamp.ops.push((
+        Op::Sha256,
+        Timestamp {
+            attestations: vec![Attestation::Bitcoin { height: 42 }],
+            ops: vec![],
+        },
+    ));
+
+    // The block commits to the *computed* digest, so this must verify...
+    let good = Chain::default().with(42, computed, 1_650_000_000);
+    assert!(establish(&p, &good).is_ok());
+
+    // ...and committing to the raw file digest must not.
+    let bad = Chain::default().with(42, file, 1_650_000_000);
+    assert!(matches!(
+        establish(&p, &bad),
+        Err(Error::MerkleRootMismatch { .. })
+    ));
+}

--- a/provenance/witness/tests/batch.rs
+++ b/provenance/witness/tests/batch.rs
@@ -1,0 +1,131 @@
+//! Batching behaviour and the limits that protect the calendars.
+
+use daon_provenance_witness::batch::{Batch, BatchPolicy};
+
+fn head(b: u8) -> [u8; 32] {
+    [b; 32]
+}
+
+#[test]
+fn every_member_proves_into_the_root() {
+    let mut batch = Batch::new();
+    for i in 0..9u8 {
+        batch.push(head(i));
+    }
+    let sealed = batch.seal().expect("non-empty");
+    assert_eq!(sealed.members.len(), 9);
+    for m in &sealed.members {
+        assert!(sealed.verify_member(m), "member {} does not prove", m.index);
+    }
+}
+
+/// One head is the degenerate case and the one most likely to be mishandled:
+/// the batch root is the head itself and the proof is empty.
+#[test]
+fn a_single_head_still_seals() {
+    let mut batch = Batch::new();
+    batch.push(head(7));
+    let sealed = batch.seal().unwrap();
+    assert_eq!(sealed.root, head(7));
+    assert!(sealed.members[0].proof.is_empty());
+    assert!(sealed.verify_member(&sealed.members[0]));
+}
+
+#[test]
+fn a_head_from_another_batch_does_not_verify() {
+    let mut a = Batch::new();
+    for i in 0..4u8 {
+        a.push(head(i));
+    }
+    let mut b = Batch::new();
+    for i in 10..14u8 {
+        b.push(head(i));
+    }
+    let (sa, sb) = (a.seal().unwrap(), b.seal().unwrap());
+    assert!(
+        !sa.verify_member(&sb.members[0]),
+        "borrowed another batch's proof"
+    );
+}
+
+#[test]
+fn duplicate_heads_are_dropped() {
+    let mut batch = Batch::new();
+    assert!(batch.push(head(1)));
+    assert!(!batch.push(head(1)));
+    assert_eq!(batch.len(), 1);
+}
+
+#[test]
+fn an_empty_batch_does_not_seal() {
+    assert!(Batch::new().seal().is_none());
+}
+
+#[test]
+fn nothing_is_submitted_for_an_empty_batch() {
+    let p = BatchPolicy::default();
+    assert!(!p.should_submit(&Batch::new(), None, None, 1_000_000));
+}
+
+/// The floor outranks every other rule. A full batch that has just been
+/// submitted still waits.
+#[test]
+fn the_rate_floor_overrides_a_full_batch() {
+    let p = BatchPolicy {
+        max_heads: 2,
+        max_wait_ms: 0,
+        min_interval_ms: 600_000,
+    };
+    let mut batch = Batch::new();
+    batch.push(head(1));
+    batch.push(head(2));
+
+    let now = 1_000_000;
+    assert!(
+        !p.should_submit(&batch, Some(0), Some(now - 1), now),
+        "submitted inside the minimum interval"
+    );
+    assert!(p.should_submit(&batch, Some(0), Some(now - 600_000), now));
+}
+
+#[test]
+fn a_full_batch_submits_once_the_floor_allows() {
+    let p = BatchPolicy {
+        max_heads: 3,
+        max_wait_ms: i64::MAX,
+        min_interval_ms: 0,
+    };
+    let mut batch = Batch::new();
+    batch.push(head(1));
+    batch.push(head(2));
+    assert!(!p.should_submit(&batch, Some(0), None, 1), "not full yet");
+    batch.push(head(3));
+    assert!(p.should_submit(&batch, Some(0), None, 1));
+}
+
+/// A slow writer must still get witnessed rather than waiting for a batch that
+/// will never fill.
+#[test]
+fn a_stale_head_submits_before_the_batch_fills() {
+    let p = BatchPolicy {
+        max_heads: 500,
+        max_wait_ms: 3_600_000,
+        min_interval_ms: 0,
+    };
+    let mut batch = Batch::new();
+    batch.push(head(1));
+    assert!(!p.should_submit(&batch, Some(0), None, 3_599_999));
+    assert!(p.should_submit(&batch, Some(0), None, 3_600_000));
+}
+
+/// A clock that jumps backwards must not unlock a burst.
+#[test]
+fn a_backwards_clock_does_not_release_the_floor() {
+    let p = BatchPolicy::default();
+    let mut batch = Batch::new();
+    for i in 0..600u16 {
+        batch.push(head((i % 256) as u8));
+    }
+    // `now` is earlier than the last submission.
+    assert!(!p.should_submit(&batch, Some(0), Some(5_000_000), 1_000));
+}

--- a/provenance/witness/tests/ots.rs
+++ b/provenance/witness/tests/ots.rs
@@ -1,0 +1,159 @@
+//! Format tests for the OpenTimestamps detached proof.
+//!
+//! The bytes here are built by hand from the spec rather than copied from a
+//! calendar response, so a bug in our own writer cannot make our own reader
+//! look correct.
+
+use daon_provenance_witness::ots::{Attestation, DetachedTimestamp, Error, Op, Timestamp, MAGIC};
+
+fn digest(b: u8) -> [u8; 32] {
+    [b; 32]
+}
+
+/// A proof whose single path ends in a Bitcoin attestation.
+fn bitcoin_proof(height: u64) -> DetachedTimestamp {
+    let mut p = DetachedTimestamp::new(digest(0xaa));
+    p.timestamp.ops.push((
+        Op::Sha256,
+        Timestamp {
+            attestations: vec![Attestation::Bitcoin { height }],
+            ops: vec![],
+        },
+    ));
+    p
+}
+
+#[test]
+fn round_trips_through_bytes() {
+    let p = bitcoin_proof(800_000);
+    let bytes = p.encode().expect("encode");
+    assert_eq!(DetachedTimestamp::decode(&bytes).expect("decode"), p);
+}
+
+#[test]
+fn starts_with_the_magic_header() {
+    let bytes = bitcoin_proof(1).encode().unwrap();
+    assert!(bytes.starts_with(MAGIC));
+    assert_eq!(bytes[MAGIC.len()], 1, "version varint");
+}
+
+#[test]
+fn rejects_a_file_that_is_not_a_proof() {
+    assert_eq!(
+        DetachedTimestamp::decode(b"not an ots file at all, not even close"),
+        Err(Error::BadMagic)
+    );
+}
+
+#[test]
+fn rejects_trailing_bytes() {
+    let mut bytes = bitcoin_proof(42).encode().unwrap();
+    bytes.push(0x00);
+    assert_eq!(DetachedTimestamp::decode(&bytes), Err(Error::TrailingBytes));
+}
+
+#[test]
+fn rejects_a_truncated_proof() {
+    let bytes = bitcoin_proof(42).encode().unwrap();
+    let cut = &bytes[..bytes.len() - 2];
+    assert_eq!(DetachedTimestamp::decode(cut), Err(Error::Truncated));
+}
+
+/// Multiple branches exercise the fork marker, which is the part of this format
+/// easiest to get wrong: 0xff precedes every item but the last, attestations
+/// included -- not just operation branches.
+#[test]
+fn round_trips_a_forked_tree_with_several_attestations() {
+    let mut p = DetachedTimestamp::new(digest(0x11));
+    p.timestamp.attestations.push(Attestation::Pending {
+        uri: b"https://alice.btc.calendar.opentimestamps.org".to_vec(),
+    });
+    p.timestamp.attestations.push(Attestation::Pending {
+        uri: b"https://bob.btc.calendar.opentimestamps.org".to_vec(),
+    });
+    p.timestamp.ops.push((
+        Op::Append(vec![0xde, 0xad]),
+        Timestamp {
+            attestations: vec![Attestation::Bitcoin { height: 700_001 }],
+            ops: vec![],
+        },
+    ));
+    p.timestamp.ops.push((
+        Op::Prepend(vec![0xbe, 0xef]),
+        Timestamp {
+            attestations: vec![Attestation::Bitcoin { height: 700_002 }],
+            ops: vec![],
+        },
+    ));
+
+    let bytes = p.encode().expect("encode");
+    assert_eq!(DetachedTimestamp::decode(&bytes).expect("decode"), p);
+}
+
+/// An unrecognised attestation type must survive a round trip rather than being
+/// dropped, or re-serializing someone's proof would silently discard part of it.
+#[test]
+fn preserves_unknown_attestations() {
+    let mut p = DetachedTimestamp::new(digest(0x22));
+    p.timestamp.attestations.push(Attestation::Unknown {
+        tag: [1, 2, 3, 4, 5, 6, 7, 8],
+        payload: b"something from the future".to_vec(),
+    });
+    let bytes = p.encode().unwrap();
+    assert_eq!(DetachedTimestamp::decode(&bytes).unwrap(), p);
+}
+
+#[test]
+fn replays_operations_to_the_attested_digest() {
+    use sha2::{Digest, Sha256};
+
+    let mut p = DetachedTimestamp::new(digest(0x33));
+    p.timestamp.ops.push((
+        Op::Append(vec![0x99]),
+        Timestamp {
+            attestations: vec![],
+            ops: vec![(
+                Op::Sha256,
+                Timestamp {
+                    attestations: vec![Attestation::Bitcoin { height: 5 }],
+                    ops: vec![],
+                },
+            )],
+        },
+    ));
+
+    let expected = Sha256::digest([digest(0x33).as_slice(), &[0x99]].concat()).to_vec();
+    let found = p.attestations().unwrap();
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].0, Attestation::Bitcoin { height: 5 });
+    assert_eq!(found[0].1, expected, "digest the path computes");
+}
+
+/// SHA-1 has been collidable since 2017. A proof routed through it could be
+/// forged, so it is refused rather than replayed.
+#[test]
+fn refuses_to_replay_sha1() {
+    assert_eq!(Op::Sha1.execute(b"anything"), Err(Error::UnknownOp(0x02)));
+}
+
+#[test]
+fn refuses_to_write_an_empty_tree() {
+    let p = DetachedTimestamp::new(digest(0x44));
+    assert_eq!(p.encode(), Err(Error::EmptyTimestamp));
+}
+
+/// A length prefix is attacker-controlled, so it must not be able to make us
+/// allocate arbitrarily.
+#[test]
+fn refuses_an_absurd_length_prefix() {
+    let mut bytes = Vec::from(MAGIC);
+    bytes.push(1); // version
+    bytes.push(0x08); // sha256 file hash op
+    bytes.extend_from_slice(&digest(0x55));
+    bytes.push(0xf0); // append
+    bytes.extend_from_slice(&[0xff, 0xff, 0xff, 0xff, 0x0f]); // huge varint
+    assert_eq!(
+        DetachedTimestamp::decode(&bytes),
+        Err(Error::LengthOutOfRange)
+    );
+}


### PR DESCRIPTION
**Merge after #111 and #112** — this branches off `feat/provenance-keychain`, so until those land the diff shows their commits too.

Nothing in `provenance/` was ever witnessed. All three crates said so in their own docs — no OpenTimestamps, no socket, no clock. Leaves were hashed, chained and signed, and none of that establishes *when*, which is the whole claim. `verify()` asked for a `WitnessAttestation` with `witness_time_ms` already filled in, and **no code anywhere could produce one**. This adds the crate that can.

## `daon-provenance-witness`

**`ots`** — the detached-proof format: parse, serialize, replay operations, read attestations.

- The fork marker is the easiest part of this format to get wrong, and it was wrong here first: `0xff` precedes every item in a node *except the last*, attestations included — not just operation branches.
- A node is terminated by the *absence* of that marker, so an empty tree has no terminator. `encode` refuses rather than writing a file nothing can parse.
- **SHA-1 parses but will not replay.** Collisions have been public since 2017, so a path through it can be forged; honouring one would let a forgery verify.
- Unknown attestation types round-trip rather than being dropped — re-serializing someone's proof shouldn't silently discard part of it.

**`batch`** — mandatory, not an optimisation. Authoring events and leaves are free and local; witnesses consume calendars running on someone else's goodwill and Bitcoin fees someone pays. Heads accumulate into a Merkle tree, one anchor covers all of them, each keeps an inclusion proof against the root.

This reuses `core`'s machinery, since it's the same construction the revision log uses. One anchor witnesses any number of heads for `log2(n)` hashes each, **and verification stays at four steps** — a batch adds a hop to the proof, never a new kind of check. The minimum interval is checked before every other rule, so no combination can produce a burst.

**`attest`** — proof + Bitcoin header → anchor. Checks the thing that matters: that the digest the proof *computes* really is that block's merkle root. A failing attestation is reported, not skipped — a proof lying about one block shouldn't quietly pass on the strength of another. Earliest surviving anchor wins, since the claim is "existed no later than T".

Headers come from a `BlockSource` this crate does not implement. Whoever supplies them decides what the entire proof rests on, and burying that choice in a library would hide the most important assumption in the system.

`needs_upgrade` gets its own function because it's the step that gets forgotten: a freshly submitted proof parses cleanly, looks finished, and proves nothing.

## Agent wiring

`WitnessLog` persists state beside the log. Proofs stored by batch root, not per head, so an upgrade can't leave two copies disagreeing. Queuing is idempotent and keeps the original timestamp — otherwise an agent re-scanning on startup keeps pushing its own deadline back and never anchors. A head stays pending until its proof is *anchored*, because submission isn't resolution.

## Tests

84 across the workspace, including one that runs the whole path: build a leaf → queue → seal → anchor the root in a block → reload proof and membership from disk → verify the claim a stranger would check.

## Not in this PR

- **Calendar submission and header fetching** — transport, belongs to the caller.
- **Rotation and transfer leaves** — blocked on the recovery-key question `key-recovery.md` says to settle *before* implementing, since retrofitting means a second format change.