### PR TITLE
feat(provenance): the agent daemon — a socket an editor can actually talk to

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -277,10 +277,17 @@ jobs:
         # Steps 1-3 of the verifier must work without signature support, and a
         # build lacking it must fail closed rather than accept any signature.
         run: cargo test -p daon-provenance-verify --no-default-features --features std
-      - name: Build for wasm32
-        # The verifier's value depends on a skeptic being able to run it in a
-        # browser without trusting a binary we shipped.
-        run: cargo build --target wasm32-unknown-unknown --release
+      - name: Build the verifier for wasm32
+        # Scoped to the verifier on purpose. Its value depends on a skeptic being
+        # able to run it in a browser without trusting a binary we shipped, so
+        # that crate must stay wasm-clean.
+        #
+        # Building the whole workspace here instead would fail, and for no useful
+        # reason: agentd is a Unix-socket daemon that will never run in a
+        # browser, and it pulls in getrandom, which refuses to compile for
+        # wasm32-unknown-unknown without a JS shim. The constraint worth
+        # enforcing is on the verifier, not on everything.
+        run: cargo build -p daon-provenance-verify --target wasm32-unknown-unknown --release
 
       - name: Reference encoder self-check
         working-directory: .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -257,6 +257,12 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: System libraries
+        # The Linux credential store talks to Secret Service over D-Bus, and
+        # `agentd` depends on the agent's keychain feature, so this is needed
+        # before the first build rather than partway down the job.
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq libdbus-1-dev pkg-config
+
       - name: Format
         run: cargo fmt --all --check
       - name: Clippy
@@ -264,12 +270,9 @@ jobs:
       - name: Tests
         run: cargo test --all-features
       - name: Check the keychain backend compiles
-        # The feature is off by default and its tests are #[ignore] -- they talk
-        # to a real OS keychain, which CI does not have. Compiling it here is
-        # what stops platform code rotting unnoticed between releases.
-        run: |
-          sudo apt-get update -qq && sudo apt-get install -y -qq libdbus-1-dev pkg-config
-          cargo check -p daon-provenance-agent --features keychain
+        # Compiling is not the same as working: the #[ignore]d tests below are
+        # what actually exercise a credential store, and they need a real one.
+        run: cargo check -p daon-provenance-agent --features keychain
       - name: Tests without optional features
         # Steps 1-3 of the verifier must work without signature support, and a
         # build lacking it must fail closed rather than accept any signature.
@@ -418,6 +421,54 @@ jobs:
 
   # ── Summary ───────────────────────────────────────────────────────────────
 
+  # ── Provenance: the keychain, on a machine that has one ───────────────────
+
+  provenance-keychain:
+    name: Provenance (macOS keychain)
+    needs: changes
+    if: needs.changes.outputs.provenance == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: provenance
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pinned toolchain
+        run: rustup toolchain install
+
+      - name: Create a throwaway keychain
+        # The ignored tests write real credentials, so they need a real keychain
+        # -- but not the runner's login keychain, which is locked and which we
+        # should not be adding secrets to anyway. A disposable one, made
+        # default for the job, keeps the blast radius inside the runner.
+        run: |
+          security create-keychain -p "" ci.keychain
+          security set-keychain-settings -lut 21600 ci.keychain
+          security unlock-keychain -p "" ci.keychain
+          security list-keychains -d user -s ci.keychain
+          security default-keychain -s ci.keychain
+
+      - name: Keychain tests
+        # These are #[ignore] by default precisely because they touch the OS.
+        # This is the one place they run.
+        run: cargo test -p daon-provenance-agent --features keychain -- --ignored --test-threads=1
+
+      - name: The daemon, on macOS
+        # agentd is exercised on Linux by the main job; running it here too
+        # catches anything that depends on Apple's socket or filesystem
+        # behaviour rather than Linux's.
+        run: cargo test -p daon-provenance-agentd
+
+      - name: Report the resolved credential store
+        # Not an assertion -- CI runs an unsigned binary, so this will report
+        # FileKeychain. It is here so the value is visible in the log if the
+        # signing story ever changes and nobody remembers to check.
+        run: cargo run -p daon-provenance-agent --features keychain --example backend
+
+      - name: Destroy the throwaway keychain
+        if: always()
+        run: security delete-keychain ci.keychain || true
+
   # ── Docs site ─────────────────────────────────────────────────────────────
 
   docs:
@@ -507,6 +558,7 @@ jobs:
       - blockchain-docker-build
       - frontend-test
       - provenance
+      - provenance-keychain
       - wordpress
       - ccc-build
       - docs
@@ -526,6 +578,7 @@ jobs:
           R_BCDOCKER:    ${{ needs.blockchain-docker-build.result }}
           R_FRONTEND:    ${{ needs.frontend-test.result }}
           R_PROVENANCE:  ${{ needs.provenance.result }}
+          R_PROVKEY:     ${{ needs.provenance-keychain.result }}
           R_WORDPRESS:   ${{ needs.wordpress.result }}
           R_CCC:         ${{ needs.ccc-build.result }}
           R_DOCS:        ${{ needs.docs.result }}
@@ -562,6 +615,7 @@ jobs:
           echo ""                              >> "$GITHUB_STEP_SUMMARY"
           echo "### Provenance"                >> "$GITHUB_STEP_SUMMARY"
           render "Rust + cross-impl check" "$R_PROVENANCE"
+          render "macOS keychain"          "$R_PROVKEY"
 
           echo ""                              >> "$GITHUB_STEP_SUMMARY"
           echo "### Integrations"              >> "$GITHUB_STEP_SUMMARY"
@@ -582,7 +636,7 @@ jobs:
           # Fail the summary job if any non-skipped job failed
           all_ok=true
           for result in "$R_SECURITY" "$R_TEST" "$R_BUILD" "$R_BLOCKCHAIN" "$R_BCDOCKER" \
-                        "$R_FRONTEND" "$R_PROVENANCE" "$R_WORDPRESS" "$R_CCC" "$R_DOCS" \
+                        "$R_FRONTEND" "$R_PROVENANCE" "$R_PROVKEY" "$R_WORDPRESS" "$R_CCC" "$R_DOCS" \
                         "$R_GO" "$R_NODE" "$R_PYTHON" "$R_RUBY" "$R_PHP"; do
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               all_ok=false

--- a/docs/design/key-recovery.md
+++ b/docs/design/key-recovery.md
@@ -174,6 +174,83 @@ about different things.
 
 ---
 
+## Rotating the recovery key
+
+**Decided.** The `author_key` may sign a leaf naming a new `recovery_key`, and it takes effect
+only after **N witnessed heads**, not at its own `seq`.
+
+### Why the recovery key must be replaceable at all
+
+A recovery key gets exposed in the ordinary course of being used. Scenario 1 of the runbook has
+the creator type it into a machine to rotate a lost author key — if that machine was the problem,
+the recovery key is now the problem. Without a way to replace it, the only remedy is abandoning
+the chain, which is the outcome this whole document exists to prevent.
+
+### Why the *author* key signs it
+
+Each key may replace the other; **neither may replace itself.**
+
+| Signed by | May replace | May not |
+| --- | --- | --- |
+| `recovery_key` | the `author_key` | the `recovery_key` |
+| `author_key` | the `recovery_key` | the `author_key` |
+
+The second row is the new rule. The first row's restriction is not new but is worth stating,
+because symmetry with transfer suggests otherwise and symmetry is wrong here.
+
+**A recovery-signed rotation must not replace the recovery key.** §4 says a hostile rotation is
+answered by counter-rotating with the same recovery key — that defence exists *because* the
+recovery key survives the rotation. If a rotation replaced it, a thief who obtained it would
+install their own on first use and the legitimate holder would have nothing left to answer with.
+Transfer replaces both keys deliberately, but transfer is authorised by the outgoing author key
+and hands the entity away on purpose; rotation is a recovery from loss and must remain
+answerable.
+
+### Why delayed, when author-key rotation is immediate
+
+Immediate would be simpler, and it is the wrong trade here — this is the one case where the
+delayed variant reserved above earns its cost.
+
+An immediate rule makes a stolen **author** key strictly more dangerous than it is today. A thief
+would replace the recovery key first, and the creator would be left holding nothing; at present
+their recovery key still rotates the thief out. Delay removes that: during the window the old
+recovery key remains valid, so an unexpected recovery-rotation can be answered.
+
+```
+seq 400   author key A, recovery key R
+seq 401   recovery-rotation, signed by A, naming R'    ← not yet in effect
+seq 402   …
+seq 415   N heads witnessed                            ← R' governs, R is dead
+```
+
+Hostile case, same leaves. The thief holds `A` and signs 401 naming their own `R'`. Because `R`
+is still valid during the window, the creator answers:
+
+```
+seq 403   rotation, signed by R → new author key B     ← the thief's A is dead
+                                                          their pending R' dies with it
+```
+
+A pending recovery-rotation is void if the author key that signed it is itself rotated out before
+the delay elapses. Otherwise the thief's replacement would land after they had already been
+removed.
+
+### What it costs the verifier
+
+**Not a fifth step.** The minimum verifier checks a signature against the `author_key` committed
+*in that leaf* and never asks whether a key legitimately changed — that was already an audit
+question, answered by walking the chain. The delay rule lives in the audit layer with the rest of
+it. An auditor comparing witness times is doing arithmetic on values it already holds.
+
+### Still to settle in implementation
+
+- **What N is.** It must exceed the time a creator plausibly takes to notice, without leaving a
+  compromised recovery key live for months. Days rather than hours or years.
+- **Encoding.** A recovery-rotation leaf must be distinguishable from a rotation leaf and from a
+  content leaf, which is the same open encoding question §*Open* already carries.
+
+---
+
 ## Custody domains — when someone else owns the hardware
 
 §3 says the two keys must not share a medium. Employment sharpens that into a different rule,
@@ -305,8 +382,7 @@ chain exists, knows what it is worth, and had months of legitimate access.
 
 ## Open
 
-- Whether the recovery key may itself be rotated. It probably must be — a compromised recovery
-  key otherwise permanently threatens an entity — but that needs its own rule, and "signed by the
-  author key" is the obvious candidate since that inverts the trust direction cleanly.
+- ~~Whether the recovery key may itself be rotated.~~ **Decided: yes, author-signed and delayed.**
+  See § *Rotating the recovery key* below.
 - Encoding. A rotation leaf needs to be distinguishable from a content leaf without an
   algorithm-agility field, which the format deliberately lacks.

--- a/provenance/Cargo.lock
+++ b/provenance/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +192,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,10 +226,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -350,6 +389,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -555,6 +595,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +620,16 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -892,12 +960,16 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
 dependencies = [
+ "aes",
+ "cbc",
  "futures-util",
  "generic-array",
  "getrandom 0.2.17",
+ "hkdf",
  "num",
  "once_cell",
  "serde",
+ "sha2",
  "zbus",
 ]
 

--- a/provenance/Cargo.lock
+++ b/provenance/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -107,6 +107,19 @@ dependencies = [
  "hex",
  "keyring-core",
  "rand",
+ "tempfile",
+]
+
+[[package]]
+name = "daon-provenance-agentd"
+version = "0.0.0"
+dependencies = [
+ "daon-provenance-agent",
+ "daon-provenance-core",
+ "daon-provenance-witness",
+ "hex",
+ "serde",
+ "serde_json",
  "tempfile",
 ]
 
@@ -228,6 +241,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "keyring-core"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +272,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "once_cell"
@@ -384,6 +409,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +479,17 @@ name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -486,5 +565,11 @@ checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/provenance/Cargo.lock
+++ b/provenance/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "apple-native-keyring-store"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,6 +21,149 @@ dependencies = [
  "log",
  "security-framework",
 ]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -29,10 +181,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "core-foundation"
@@ -58,6 +244,12 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -108,6 +300,8 @@ dependencies = [
  "keyring-core",
  "rand",
  "tempfile",
+ "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
 ]
 
 [[package]]
@@ -181,6 +375,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +415,26 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -201,6 +448,61 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -235,16 +537,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "keyring-core"
@@ -280,10 +615,138 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -292,6 +755,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -349,6 +821,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "ripemd"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +878,27 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "secret-service"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
+dependencies = [
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "num",
+ "once_cell",
+ "serde",
+ "zbus",
 ]
 
 [[package]]
@@ -452,6 +974,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,10 +996,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "subtle"
@@ -510,16 +1059,99 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "uuid"
+version = "1.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
@@ -534,10 +1166,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys",
+ "zeroize",
+]
 
 [[package]]
 name = "windows-sys"
@@ -546,6 +1236,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -569,7 +1349,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zvariant"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d80ece222cad20fe0e8741be493c4ab166acf3b85341bdc2cdbcfd8f3c2d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
+ "winnow",
+]

--- a/provenance/Cargo.toml
+++ b/provenance/Cargo.toml
@@ -22,5 +22,10 @@ tempfile = "3"
 keyring-core = "1"
 apple-native-keyring-store = { version = "1", features = ["keychain", "protected"] }
 windows-native-keyring-store = "1"
-zbus-secret-service-keyring-store = "1"
+# The secret-service crate refuses to compile without a runtime chosen, so one
+# must be named here. async-io rather than tokio because the daemon is sync and
+# thread-per-connection -- pulling in an async runtime it never drives would be
+# dead weight -- and crypto-rust rather than openssl to avoid a system library
+# on every Linux build.
+zbus-secret-service-keyring-store = { version = "1", default-features = false, features = ["rt-async-io-crypto-rust"] }
 rand = "0.8"

--- a/provenance/Cargo.toml
+++ b/provenance/Cargo.toml
@@ -21,4 +21,6 @@ tempfile = "3"
 # keychain on macOS and offers no way to override it.
 keyring-core = "1"
 apple-native-keyring-store = { version = "1", features = ["keychain", "protected"] }
+windows-native-keyring-store = "1"
+zbus-secret-service-keyring-store = "1"
 rand = "0.8"

--- a/provenance/Cargo.toml
+++ b/provenance/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["core", "verify", "agent", "witness"]
+members = ["core", "verify", "agent", "witness", "agentd"]
 
 [workspace.package]
 edition = "2021"
@@ -13,6 +13,7 @@ sha2 = { version = "0.10", default-features = false }
 ed25519-dalek = { version = "2", default-features = false }
 daon-provenance-core = { path = "core", default-features = false }
 daon-provenance-witness = { path = "witness", default-features = false }
+daon-provenance-agent = { path = "agent" }
 hex = "0.4"
 tempfile = "3"
 # Registering the protected (data-protection) store ourselves means talking to

--- a/provenance/agent/Cargo.toml
+++ b/provenance/agent/Cargo.toml
@@ -19,6 +19,12 @@ rand = { workspace = true, optional = true }
 
 # The protected (data-protection) store lives here; keyring's `v1` shim will
 # only ever give us the non-syncing file keychain on macOS.
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-native-keyring-store = { workspace = true, optional = true }
+
+[target.'cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))'.dependencies]
+zbus-secret-service-keyring-store = { workspace = true, optional = true }
+
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dev-dependencies]
 apple-native-keyring-store = { workspace = true }
 
@@ -33,6 +39,8 @@ keychain = [
     "dep:ed25519-dalek",
     "dep:rand",
     "dep:apple-native-keyring-store",
+    "dep:windows-native-keyring-store",
+    "dep:zbus-secret-service-keyring-store",
 ]
 
 # Reports the resolved credential store, which only exists with the feature that

--- a/provenance/agent/src/keystore.rs
+++ b/provenance/agent/src/keystore.rs
@@ -72,6 +72,19 @@ static BACKEND: OnceLock<Backend> = OnceLock::new();
 
 /// Register the credential store, once per process.
 ///
+/// # This probes the keychain, and probing prompts
+///
+/// Each candidate is tried with a real write, so on macOS an **unsigned build
+/// prompts the user on every process start** -- and "Always Allow" does not
+/// help, because that grant is bound to the binary's exact code signature and
+/// `cargo build` re-signs ad-hoc on every rebuild. Every build looks like a
+/// different application.
+///
+/// A signed app with a stable Developer ID is granted once and never asked
+/// again. So this is not only about iCloud sync: an unsigned agent is unusable
+/// in daily practice regardless of entitlements, because it interrogates the
+/// creator every time it starts.
+///
 /// Must run before any credential is built. Note that this crate deliberately
 /// does not use `keyring::Entry`: that shim's `new` forces a `LazyLock` which
 /// calls `set_default_store` with the file keychain, discarding whatever was

--- a/provenance/agent/src/keystore.rs
+++ b/provenance/agent/src/keystore.rs
@@ -34,7 +34,6 @@
 //! takes two devices on one Apple ID. Until someone has done that against a
 //! signed build, no caller should print "your key is on all your devices."
 
-use std::collections::HashMap;
 use std::sync::OnceLock;
 
 /// Which store the author key landed in.
@@ -101,6 +100,7 @@ pub fn init() -> Backend {
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 fn register() -> Backend {
     use keyring_core::api::CredentialStoreApi;
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     type Store = Arc<dyn CredentialStoreApi + Send + Sync>;
@@ -157,11 +157,31 @@ fn probe(store: &std::sync::Arc<dyn keyring_core::api::CredentialStoreApi + Send
     ok
 }
 
+/// Windows Credential Manager and Linux Secret Service. Neither has a
+/// synchronized variant to opt into.
+///
+/// These must be registered explicitly. Dropping the `keyring` v1 shim removed
+/// the thing that used to install a platform store on these targets, and
+/// because the keychain tests are `#[ignore]`d and CI only ran `cargo check`,
+/// nothing noticed that every credential operation off Apple would fail with
+/// `NoDefaultStore`.
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]
 fn register() -> Backend {
-    // Windows Credential Manager and Linux Secret Service are what keyring
-    // installs by default, and neither offers a synchronized variant.
-    let _ = HashMap::<&str, &str>::new();
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(store) = windows_native_keyring_store::Store::new() {
+            keyring_core::set_default_store(store);
+        }
+    }
+    #[cfg(all(
+        unix,
+        not(any(target_os = "macos", target_os = "ios", target_os = "android"))
+    ))]
+    {
+        if let Ok(store) = zbus_secret_service_keyring_store::Store::new() {
+            keyring_core::set_default_store(store);
+        }
+    }
     Backend::Platform
 }
 

--- a/provenance/agentd/Cargo.toml
+++ b/provenance/agentd/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "daon-provenance-agentd"
+version = "0.0.0"          # not published; the wire format is not frozen yet
+description = "The DAON provenance agent daemon: a local socket an editor talks to"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+name = "daon_provenance_agentd"
+path = "src/lib.rs"
+
+[[bin]]
+name = "daon-provenance-agentd"
+path = "src/main.rs"
+
+[dependencies]
+daon-provenance-core.workspace = true
+daon-provenance-agent = { workspace = true, features = ["keychain"] }
+daon-provenance-witness.workspace = true
+# Hand-rolling a JSON parser is the one place in this project where doing it
+# ourselves would be reckless rather than principled: the input is
+# attacker-shaped and the failure modes are subtle. HTTP is different -- see
+# http.rs.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+hex.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/provenance/agentd/src/api.rs
+++ b/provenance/agentd/src/api.rs
@@ -1,0 +1,542 @@
+//! The routes from `editor-integration-spec.md` §3.
+//!
+//! Everything here is a thin composition over parts that already exist and are
+//! tested — `policy` decides, `Store` appends, `WitnessLog` queues. The daemon's
+//! job is to hold them together and to enforce the one rule the spec opens with:
+//!
+//! > The editor reports what it observed. It never reports what the content is.
+//!
+//! Which is why there is no route that accepts a claim about origin, and why
+//! `ingress` is a closed enum with `unknown` as an honest member rather than a
+//! failure.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use daon_provenance_agent::policy::{CommitReason, Decision, Limits, Observed, Session};
+use daon_provenance_agent::witness::WitnessLog;
+use daon_provenance_agent::{Signer, Store};
+use daon_provenance_core::{Beacon, BeaconChain, Hash, Ingress, Observation};
+use serde::{Deserialize, Serialize};
+
+use crate::http::{error_body, Request};
+
+/// A response ready to write: status, JSON body, extra headers.
+pub struct Reply {
+    pub status: u16,
+    pub body: Vec<u8>,
+    pub headers: Vec<(String, String)>,
+}
+
+impl Reply {
+    fn ok<T: Serialize>(value: &T) -> Reply {
+        Reply {
+            status: 200,
+            body: serde_json::to_vec(value)
+                .unwrap_or_else(|_| error_body("internal", "response could not be serialized")),
+            headers: Vec::new(),
+        }
+    }
+
+    pub fn err(status: u16, code: &str, message: &str) -> Reply {
+        Reply {
+            status,
+            body: error_body(code, message),
+            headers: Vec::new(),
+        }
+    }
+
+    fn with_header(mut self, k: &str, v: String) -> Reply {
+        self.headers.push((k.to_string(), v));
+        self
+    }
+}
+
+/// Everything the daemon owns, behind one lock.
+///
+/// A single mutex rather than fine-grained locking: requests are infrequent and
+/// short, the store is the shared resource anyway, and a coarse lock that is
+/// obviously correct beats a clever one that is not. If this ever becomes a
+/// bottleneck it will be visible in the timings rather than in a corrupted log.
+pub struct Agent {
+    inner: Mutex<Inner>,
+}
+
+struct Inner {
+    store: Store,
+    witness: WitnessLog,
+    signer: Box<dyn Signer + Send>,
+    limits: Limits,
+    sessions: HashMap<String, Live>,
+    next_session: u64,
+}
+
+struct Live {
+    entity: Option<Hash>,
+    tool_id: Vec<u8>,
+    policy: Session,
+}
+
+impl Agent {
+    pub fn new(
+        store: Store,
+        witness: WitnessLog,
+        signer: Box<dyn Signer + Send>,
+        limits: Limits,
+    ) -> Self {
+        Agent {
+            inner: Mutex::new(Inner {
+                store,
+                witness,
+                signer,
+                limits,
+                sessions: HashMap::new(),
+                next_session: 1,
+            }),
+        }
+    }
+
+    /// Dispatch a request. Unknown paths 404 rather than falling through to
+    /// anything.
+    pub fn handle(&self, req: &Request, now_ms: i64) -> Reply {
+        match (req.method.as_str(), req.path.as_str()) {
+            ("POST", "/v1/session/open") => self.session_open(req, now_ms),
+            ("POST", "/v1/observe") => self.observe(req, now_ms),
+            ("POST", "/v1/commit") => self.commit(req, now_ms),
+            ("GET", p) if p.starts_with("/v1/entity/") && p.ends_with("/proof") => {
+                self.proof(req, p)
+            }
+            ("POST", _) | ("GET", _) => Reply::err(404, "not_found", "no such route"),
+            _ => Reply::err(405, "method_not_allowed", "unsupported method"),
+        }
+    }
+}
+
+// ── POST /v1/session/open ─────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct OpenReq {
+    /// Omitted to create a new entity.
+    entity_id: Option<String>,
+    tool_id: String,
+}
+
+#[derive(Serialize)]
+struct OpenResp {
+    session: String,
+    entity_id: Option<String>,
+    head: Option<String>,
+    head_seq: Option<u64>,
+    limits: LimitsResp,
+}
+
+#[derive(Serialize)]
+struct LimitsResp {
+    min_commit_interval_ms: u64,
+    daily_leaf_budget: u32,
+    leaves_remaining_today: u32,
+}
+
+impl Agent {
+    fn session_open(&self, req: &Request, now_ms: i64) -> Reply {
+        let body: OpenReq = match parse(&req.body) {
+            Ok(b) => b,
+            Err(r) => return r,
+        };
+        if body.tool_id.is_empty() || body.tool_id.len() > 64 || !body.tool_id.is_ascii() {
+            return Reply::err(400, "bad_tool_id", "tool_id must be 1-64 ASCII bytes");
+        }
+
+        let mut inner = self.inner.lock().unwrap();
+
+        let entity = match &body.entity_id {
+            Some(s) => match parse_hash(s) {
+                Some(h) => Some(h),
+                None => return Reply::err(400, "bad_entity_id", "expected sha256:<64 hex>"),
+            },
+            None => None,
+        };
+
+        // An entity named but absent is a client error, not a silent genesis.
+        // Creating a fresh chain because a lookup failed would fork history
+        // exactly when someone thought they were continuing it.
+        let (head, head_seq) = match entity {
+            Some(e) => match inner.store.head(&e) {
+                Ok(h) => {
+                    let seq = inner.store.len(&e).unwrap_or(0);
+                    (Some(h), Some(seq.saturating_sub(1)))
+                }
+                Err(_) => return Reply::err(404, "unknown_entity", "no such entity in this store"),
+            },
+            None => (None, None),
+        };
+
+        let limits = inner.limits;
+        let id = format!("s_{:016x}", inner.next_session);
+        inner.next_session += 1;
+        let policy = Session::new(limits, now_ms);
+        let remaining = limits
+            .daily_leaf_budget
+            .saturating_sub(policy.leaves_today());
+
+        inner.sessions.insert(
+            id.clone(),
+            Live {
+                entity,
+                tool_id: body.tool_id.clone().into_bytes(),
+                policy,
+            },
+        );
+
+        Reply::ok(&OpenResp {
+            session: id,
+            entity_id: entity.as_ref().map(hex_id),
+            head: head.as_ref().map(hex_id),
+            head_seq,
+            limits: LimitsResp {
+                min_commit_interval_ms: limits.min_commit_interval_ms,
+                daily_leaf_budget: limits.daily_leaf_budget,
+                leaves_remaining_today: remaining,
+            },
+        })
+    }
+}
+
+// ── POST /v1/observe ──────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct ObserveReq {
+    session: String,
+    ingress: String,
+    span_bytes: Span,
+    op_count: u64,
+    duration_ms: u64,
+}
+
+#[derive(Deserialize)]
+struct Span {
+    added: u64,
+    removed: u64,
+}
+
+#[derive(Serialize)]
+struct ObserveResp {
+    accepted: bool,
+    throttled: bool,
+    pending_observations: usize,
+}
+
+impl Agent {
+    fn observe(&self, req: &Request, now_ms: i64) -> Reply {
+        let body: ObserveReq = match parse(&req.body) {
+            Ok(b) => b,
+            Err(r) => return r,
+        };
+        // An unrecognised ingress is refused rather than mapped to `unknown`.
+        // `unknown` is an honest answer a tool chooses; silently substituting it
+        // for a typo would put a claim in the log the client never made.
+        let Some(ingress) = ingress_from(&body.ingress) else {
+            return Reply::err(400, "bad_ingress", "not a defined ingress value");
+        };
+
+        let mut inner = self.inner.lock().unwrap();
+        let Some(live) = inner.sessions.get_mut(&body.session) else {
+            return Reply::err(404, "unknown_session", "no such session");
+        };
+
+        let observation = Observation {
+            tool_id: live.tool_id.clone(),
+            ingress,
+            added: body.span_bytes.added,
+            removed: body.span_bytes.removed,
+            duration_ms: body.duration_ms,
+            op_count: body.op_count,
+        };
+
+        let outcome = live.policy.observe(observation, now_ms);
+        let throttled = matches!(outcome, Observed::Throttled);
+        Reply::ok(&ObserveResp {
+            accepted: !throttled,
+            throttled,
+            pending_observations: live.policy.pending().len(),
+        })
+    }
+}
+
+// ── POST /v1/commit ───────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct CommitReq {
+    session: String,
+    content: String,
+    reason: String,
+}
+
+#[derive(Serialize)]
+struct Committed {
+    committed: bool,
+    seq: u64,
+    head: String,
+    leaf: String,
+    entity_id: String,
+}
+
+#[derive(Serialize)]
+struct NotCommitted {
+    committed: bool,
+    reason: &'static str,
+    retry_after_ms: u64,
+}
+
+impl Agent {
+    fn commit(&self, req: &Request, now_ms: i64) -> Reply {
+        let body: CommitReq = match parse(&req.body) {
+            Ok(b) => b,
+            Err(r) => return r,
+        };
+        let Some(reason) = reason_from(&body.reason) else {
+            return Reply::err(400, "bad_reason", "not a defined commit reason");
+        };
+
+        let mut inner = self.inner.lock().unwrap();
+        let Some(live) = inner.sessions.get_mut(&body.session) else {
+            return Reply::err(404, "unknown_session", "no such session");
+        };
+
+        match live.policy.decide(reason, now_ms) {
+            Decision::Commit => {}
+            Decision::Coalesce { retry_after_ms } => {
+                return Reply::ok(&NotCommitted {
+                    committed: false,
+                    reason: "coalesced",
+                    retry_after_ms,
+                })
+            }
+            Decision::RateLimited { retry_after_ms } => {
+                return Reply::ok(&NotCommitted {
+                    committed: false,
+                    reason: "rate_limited",
+                    retry_after_ms,
+                })
+            }
+            Decision::BudgetExhausted { retry_after_ms } => {
+                return Reply::err(429, "budget_exhausted", "daily leaf budget spent")
+                    .with_header("Retry-After", (retry_after_ms / 1000).max(1).to_string())
+            }
+        }
+
+        let observations = live.policy.take_for_commit(now_ms);
+        if observations.is_empty() {
+            return Reply::err(
+                400,
+                "no_observations",
+                "a leaf must commit to at least one observation",
+            );
+        }
+
+        let entity = live.entity;
+        let tool = live.tool_id.clone();
+        let _ = tool;
+
+        // The beacon is a free lower bound on time, taken from a recent Bitcoin
+        // block. Until the daemon has a block source this is the zero beacon,
+        // which is honest: it claims nothing rather than claiming an unverified
+        // height. See the note in main.rs.
+        let beacon = Beacon {
+            chain: BeaconChain::Bitcoin,
+            height: 0,
+            block_hash: [0u8; 32],
+        };
+
+        let Inner {
+            store,
+            witness,
+            signer,
+            sessions,
+            ..
+        } = &mut *inner;
+
+        let appended = store.append(
+            entity.as_ref(),
+            body.content.as_bytes(),
+            &observations,
+            beacon,
+            signer.as_ref(),
+            now_ms,
+        );
+
+        let (entity_id, leaf) = match appended {
+            Ok(v) => v,
+            Err(e) => return Reply::err(500, "append_failed", &e.to_string()),
+        };
+
+        // A new entity's id is only known after genesis, so the session learns
+        // it here and subsequent commits continue the same chain.
+        if let Some(live) = sessions.get_mut(&body.session) {
+            live.entity = Some(entity_id);
+        }
+
+        let head = match store.head(&entity_id) {
+            Ok(h) => h,
+            Err(e) => return Reply::err(500, "head_failed", &e.to_string()),
+        };
+
+        // Queue for witnessing. A failure here must not lose the leaf, which is
+        // already durable -- it means this head is unwitnessed until the next
+        // sweep picks it up.
+        if let Err(e) = witness.queue(&head, now_ms) {
+            eprintln!("warning: could not queue head for witnessing: {e}");
+        }
+
+        Reply::ok(&Committed {
+            committed: true,
+            seq: leaf.leaf.seq,
+            head: hex_id(&head),
+            leaf: hex_id(&leaf.leaf.leaf_id()),
+            entity_id: hex_id(&entity_id),
+        })
+    }
+}
+
+// ── GET /v1/entity/{id}/proof?seq=N ───────────────────────────────────────
+
+#[derive(Serialize)]
+struct ProofResp {
+    leaf: String,
+    seq: u64,
+    inclusion_proof: Vec<ProofStepResp>,
+    head: String,
+    witness_state: &'static str,
+    witness_receipt: Option<WitnessReceipt>,
+}
+
+#[derive(Serialize)]
+struct ProofStepResp {
+    side: &'static str,
+    hash: String,
+}
+
+#[derive(Serialize)]
+struct WitnessReceipt {
+    batch_root: String,
+    /// Base16 of the stored `.ots`. Opaque to the editor; it belongs to whoever
+    /// verifies.
+    ots: String,
+}
+
+impl Agent {
+    fn proof(&self, req: &Request, path: &str) -> Reply {
+        let id = path
+            .trim_start_matches("/v1/entity/")
+            .trim_end_matches("/proof");
+        let Some(entity) = parse_hash(id) else {
+            return Reply::err(400, "bad_entity_id", "expected sha256:<64 hex> or 64 hex");
+        };
+        let Some(seq) = req.query.get("seq").and_then(|s| s.parse::<u64>().ok()) else {
+            return Reply::err(400, "bad_seq", "seq query parameter required");
+        };
+
+        let inner = self.inner.lock().unwrap();
+        let (stored, proof) = match inner.store.proof(&entity, seq) {
+            Ok(v) => v,
+            Err(e) => return Reply::err(404, "no_such_leaf", &e.to_string()),
+        };
+        let head = match inner.store.head(&entity) {
+            Ok(h) => h,
+            Err(e) => return Reply::err(500, "head_failed", &e.to_string()),
+        };
+
+        // A head that is still queued is pending by definition. This reports
+        // `pending` rather than an error, because pending is the normal state
+        // for minutes to hours after writing and an editor must not treat it as
+        // a failure.
+        let pending = inner
+            .witness
+            .pending()
+            .map(|p| p.iter().any(|h| h.head == head))
+            .unwrap_or(true);
+
+        let receipt = if pending {
+            None
+        } else {
+            find_receipt(&inner.witness, &head)
+        };
+
+        Reply::ok(&ProofResp {
+            leaf: hex::encode(stored.leaf.encode()),
+            seq,
+            inclusion_proof: proof
+                .iter()
+                .map(|(side, h)| ProofStepResp {
+                    side: match side {
+                        daon_provenance_core::Side::Left => "left",
+                        daon_provenance_core::Side::Right => "right",
+                    },
+                    hash: hex::encode(h),
+                })
+                .collect(),
+            head: hex_id(&head),
+            witness_state: if receipt.is_some() {
+                "witnessed"
+            } else {
+                "pending"
+            },
+            witness_receipt: receipt,
+        })
+    }
+}
+
+fn find_receipt(witness: &WitnessLog, head: &Hash) -> Option<WitnessReceipt> {
+    for root in witness.batches().ok()? {
+        let members = witness.members(&root).ok()?;
+        if members.iter().any(|m| &m.head == head) {
+            return Some(WitnessReceipt {
+                batch_root: hex_id(&root),
+                ots: hex::encode(witness.proof(&root).ok()?),
+            });
+        }
+    }
+    None
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+fn parse<T: for<'de> Deserialize<'de>>(body: &[u8]) -> Result<T, Reply> {
+    serde_json::from_slice(body)
+        .map_err(|e| Reply::err(400, "bad_request", &format!("invalid JSON body: {e}")))
+}
+
+fn hex_id(h: &Hash) -> String {
+    format!("sha256:{}", hex::encode(h))
+}
+
+fn parse_hash(s: &str) -> Option<Hash> {
+    let s = s.strip_prefix("sha256:").unwrap_or(s);
+    if s.len() != 64 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    hex::decode_to_slice(s, &mut out).ok()?;
+    Some(out)
+}
+
+fn ingress_from(s: &str) -> Option<Ingress> {
+    Some(match s {
+        "keystroke_stream" => Ingress::KeystrokeStream,
+        "paste" => Ingress::Paste,
+        "import" => Ingress::Import,
+        "programmatic" => Ingress::Programmatic,
+        "unknown" => Ingress::Unknown,
+        _ => return None,
+    })
+}
+
+fn reason_from(s: &str) -> Option<CommitReason> {
+    Some(match s {
+        "idle" => CommitReason::Idle,
+        "save" => CommitReason::Save,
+        "close" => CommitReason::Close,
+        "explicit" => CommitReason::Explicit,
+        _ => return None,
+    })
+}

--- a/provenance/agentd/src/http.rs
+++ b/provenance/agentd/src/http.rs
@@ -1,0 +1,220 @@
+//! Just enough HTTP/1.1 to serve the editor API over a Unix socket.
+//!
+//! # Why not a web framework
+//!
+//! The surface is four routes over a `0600` socket on the local machine. Pulling
+//! in an async runtime and a full server stack for that would add far more code
+//! than it replaced, and every line of it would also be reachable from the same
+//! socket.
+//!
+//! The usual argument for a real HTTP library is that HTTP parsing is
+//! security-critical because it faces the internet. This never does: the spec is
+//! normative that the transport is a Unix domain socket and **never a TCP port,
+//! loopback included**. Anything that can open the socket is already running as
+//! the creator.
+//!
+//! So this parses the small, strict subset the spec needs and refuses the rest.
+//! Notably it does **not** implement chunked transfer encoding, pipelining, or
+//! keep-alive — a request without a `Content-Length` is rejected rather than
+//! guessed at.
+//!
+//! JSON is a different judgement: see the note in `Cargo.toml`.
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Read, Write};
+
+/// Bodies larger than this are refused before being read.
+///
+/// A commit carries the full buffer, so this has to accommodate a real
+/// manuscript — but not an unbounded one, or a single request could exhaust
+/// memory.
+pub const MAX_BODY: usize = 64 * 1024 * 1024;
+
+/// The request line and headers are tiny; anything larger is malformed.
+const MAX_HEAD: usize = 16 * 1024;
+
+/// A parsed request.
+pub struct Request {
+    pub method: String,
+    /// Path with any query string removed.
+    pub path: String,
+    /// Decoded query parameters, empty if there was no query string.
+    pub query: HashMap<String, String>,
+    pub body: Vec<u8>,
+}
+
+/// Why a request could not be read.
+#[derive(Debug)]
+pub enum Error {
+    Io(std::io::Error),
+    /// Malformed beyond the point of a useful reply.
+    Malformed(&'static str),
+    /// Well-formed but larger than [`MAX_BODY`].
+    TooLarge,
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+impl Request {
+    /// Read one request. Does not support keep-alive: one request per
+    /// connection, which is all the spec's flow needs and removes a whole class
+    /// of framing bugs.
+    pub fn read<R: Read>(stream: R) -> Result<Request, Error> {
+        let mut reader = BufReader::new(stream);
+
+        let mut line = String::new();
+        read_line(&mut reader, &mut line)?;
+        let mut parts = line.split_whitespace();
+        let method = parts
+            .next()
+            .ok_or(Error::Malformed("no method"))?
+            .to_string();
+        let target = parts.next().ok_or(Error::Malformed("no path"))?.to_string();
+
+        // Require a recognisable version token. Without this a request line of
+        // arbitrary junk parses as a method and a path and is only rejected
+        // later by the router, which reports the wrong problem.
+        match parts.next() {
+            Some(v) if v.starts_with("HTTP/1.") => {}
+            _ => return Err(Error::Malformed("not an HTTP/1.x request line")),
+        }
+
+        let mut headers = HashMap::new();
+        let mut consumed = line.len();
+        loop {
+            let mut h = String::new();
+            read_line(&mut reader, &mut h)?;
+            consumed += h.len();
+            if consumed > MAX_HEAD {
+                return Err(Error::Malformed("headers too large"));
+            }
+            let h = h.trim_end();
+            if h.is_empty() {
+                break;
+            }
+            let (k, v) = h.split_once(':').ok_or(Error::Malformed("bad header"))?;
+            headers.insert(k.trim().to_ascii_lowercase(), v.trim().to_string());
+        }
+
+        // No Content-Length means no body. A body without one would need chunked
+        // decoding, which is not implemented and is not guessed at.
+        let len: usize = match headers.get("content-length") {
+            Some(v) => v.parse().map_err(|_| Error::Malformed("bad length"))?,
+            None => 0,
+        };
+        if len > MAX_BODY {
+            return Err(Error::TooLarge);
+        }
+        let mut body = vec![0u8; len];
+        reader.read_exact(&mut body)?;
+
+        let (path, query) = match target.split_once('?') {
+            Some((p, q)) => (p.to_string(), parse_query(q)),
+            None => (target, HashMap::new()),
+        };
+
+        Ok(Request {
+            method,
+            path,
+            query,
+            body,
+        })
+    }
+}
+
+fn read_line<R: BufRead>(reader: &mut R, out: &mut String) -> Result<(), Error> {
+    out.clear();
+    let n = reader.read_line(out)?;
+    if n == 0 {
+        return Err(Error::Malformed("connection closed mid-request"));
+    }
+    Ok(())
+}
+
+fn parse_query(q: &str) -> HashMap<String, String> {
+    q.split('&')
+        .filter(|s| !s.is_empty())
+        .filter_map(|pair| {
+            let (k, v) = pair.split_once('=')?;
+            Some((percent_decode(k), percent_decode(v)))
+        })
+        .collect()
+}
+
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'%' if i + 2 < bytes.len() => {
+                match u8::from_str_radix(&s[i + 1..i + 3], 16) {
+                    Ok(b) => {
+                        out.push(b);
+                        i += 3;
+                    }
+                    // Not a valid escape; keep it literal rather than dropping
+                    // it, so a malformed query cannot silently become a
+                    // different valid one.
+                    Err(_) => {
+                        out.push(b'%');
+                        i += 1;
+                    }
+                }
+            }
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Write a JSON response.
+pub fn respond<W: Write>(
+    mut w: W,
+    status: u16,
+    body: &[u8],
+    extra: &[(&str, &str)],
+) -> std::io::Result<()> {
+    let reason = match status {
+        200 => "OK",
+        400 => "Bad Request",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        413 => "Payload Too Large",
+        429 => "Too Many Requests",
+        500 => "Internal Server Error",
+        _ => "Unknown",
+    };
+    write!(
+        w,
+        "HTTP/1.1 {status} {reason}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n",
+        body.len()
+    )?;
+    for (k, v) in extra {
+        write!(w, "{k}: {v}\r\n")?;
+    }
+    w.write_all(b"\r\n")?;
+    w.write_all(body)?;
+    w.flush()
+}
+
+/// A JSON error body, in one shape everywhere so clients can rely on it.
+pub fn error_body(code: &str, message: &str) -> Vec<u8> {
+    serde_json::json!({ "error": code, "message": message })
+        .to_string()
+        .into_bytes()
+}

--- a/provenance/agentd/src/lib.rs
+++ b/provenance/agentd/src/lib.rs
@@ -1,0 +1,12 @@
+//! The DAON provenance agent, as a library.
+//!
+//! The daemon binary is a thin shell over this: argument parsing, socket
+//! binding, and a thread per connection. Everything with behaviour worth
+//! checking lives here so it can be tested without a socket, a keychain or a
+//! clock.
+
+pub mod api;
+pub mod http;
+pub mod server;
+
+pub use api::{Agent, Reply};

--- a/provenance/agentd/src/main.rs
+++ b/provenance/agentd/src/main.rs
@@ -1,0 +1,161 @@
+//! The DAON provenance agent daemon.
+//!
+//! ```text
+//! daon-provenance-agentd --store ~/.daon/provenance [--socket PATH] [--identity NAME]
+//! ```
+//!
+//! Binds a Unix domain socket and serves the four routes in
+//! `editor-integration-spec.md` §3. Everything it does is composed from crates
+//! that are separately tested; this binary is the wiring and the parts that
+//! cannot be tested without a real filesystem and a real socket.
+//!
+//! # Transport, and why there is no `--port`
+//!
+//! The spec is normative: a Unix domain socket, mode `0600`, **never a TCP port,
+//! loopback included**. Its reasoning is worth repeating because it is the kind
+//! of thing that erodes — *"a debug flag that opens a port is a debug flag that
+//! ships."* So there is no flag. Adding one later means arguing with the spec,
+//! which is the point.
+//!
+//! A caller that can open the socket is already running as the creator and could
+//! read the key material directly. The socket is not defending against that. It
+//! is defending against every other process on a shared machine.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use daon_provenance_agent::keychain::KeychainSigner;
+use daon_provenance_agent::keystore;
+use daon_provenance_agent::policy::Limits;
+use daon_provenance_agent::witness::WitnessLog;
+use daon_provenance_agent::Store;
+
+use daon_provenance_agentd::{api::Agent, server};
+
+fn main() -> std::process::ExitCode {
+    match run() {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("daon-provenance-agentd: {e}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+struct Args {
+    store: PathBuf,
+    socket: PathBuf,
+    identity: String,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut store = None;
+    let mut socket = None;
+    let mut identity = "default".to_string();
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--store" => store = Some(PathBuf::from(need(&mut args, "--store")?)),
+            "--socket" => socket = Some(PathBuf::from(need(&mut args, "--socket")?)),
+            "--identity" => identity = need(&mut args, "--identity")?,
+            "-h" | "--help" => {
+                println!(
+                    "daon-provenance-agentd --store PATH [--socket PATH] [--identity NAME]\n\
+                     \n\
+                       --store     where leaves, blobs and witness state live (required)\n\
+                       --socket    socket path (default: <store>/agent.sock)\n\
+                       --identity  which keychain identity to sign with (default: default)\n\
+                     \n\
+                     There is deliberately no --port. See the module docs."
+                );
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown argument {other}")),
+        }
+    }
+
+    let store = store.ok_or("--store is required")?;
+    let socket = socket.unwrap_or_else(|| store.join("agent.sock"));
+    Ok(Args {
+        store,
+        socket,
+        identity,
+    })
+}
+
+fn need(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<String, String> {
+    args.next().ok_or(format!("{flag} needs a value"))
+}
+
+fn run() -> Result<(), String> {
+    let args = parse_args()?;
+
+    let store = Store::open(&args.store).map_err(|e| format!("opening store: {e}"))?;
+    let witness = WitnessLog::open(&args.store).map_err(|e| format!("witness state: {e}"))?;
+
+    // Load, or create on first run. Creating returns the recovery secret exactly
+    // once, and this is the only moment it can be shown to anyone.
+    let signer = match KeychainSigner::load(&args.identity) {
+        Ok(s) => s,
+        Err(_) => {
+            let (signer, recovery) = KeychainSigner::create(&args.identity)
+                .map_err(|e| format!("creating identity: {e}"))?;
+            announce_new_identity(recovery, &args.identity);
+            signer
+        }
+    };
+
+    let backend = keystore::init();
+    eprintln!("credential store: {backend:?}");
+    if !backend.sync_requested() {
+        eprintln!(
+            "note: this build's keys stay on this device. Sync needs a signed app \
+             with the iCloud entitlement -- see keystore.rs."
+        );
+    }
+
+    let agent = Arc::new(Agent::new(
+        store,
+        witness,
+        Box::new(signer),
+        Limits::default(),
+    ));
+
+    let listener = server::bind(&args.socket)?;
+    eprintln!("listening on {}", args.socket.display());
+    server::serve_forever(agent, listener, now_ms);
+    Ok(())
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        // A clock before the epoch is nonsense, but `local_time_ms` is declared
+        // untrusted and signed i64 precisely so it can hold nonsense rather than
+        // panicking here.
+        .unwrap_or(0)
+}
+
+/// Show the recovery secret. Once.
+fn announce_new_identity(
+    recovery: daon_provenance_agent::keychain::RecoverySecret,
+    identity: &str,
+) {
+    let managed = keystore::is_managed_device();
+    let secret = hex::encode(recovery.reveal());
+
+    eprintln!("\n  A new identity '{identity}' was created.\n");
+    eprintln!("  Recovery key (shown once, never stored):\n");
+    eprintln!("      {secret}\n");
+    eprintln!("  Write it somewhere the signing key is not. If this laptop dies,");
+    eprintln!("  this is the only thing that can continue your chains.\n");
+    if managed {
+        eprintln!("  ⚠  This machine appears to be centrally managed by an organisation.");
+        eprintln!("     Do not store the recovery key anywhere your employer controls --");
+        eprintln!("     not this laptop, not a corporate password vault, not work email.");
+        eprintln!("     See docs/design/key-recovery.md, 'Custody domains'.\n");
+    }
+}

--- a/provenance/agentd/src/server.rs
+++ b/provenance/agentd/src/server.rs
@@ -1,0 +1,118 @@
+//! Binding the socket and serving connections.
+//!
+//! Separate from `main.rs` so it can be tested against a real socket with a test
+//! signer, rather than only against whatever identity happens to be in the
+//! machine's keychain.
+
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::api::{Agent, Reply};
+use crate::http;
+
+/// Bind a Unix socket at `path` with mode `0600`.
+///
+/// Permissions are applied immediately after bind. A permissive umask could
+/// otherwise leave a window where the socket is connectable by other users, and
+/// that window falls at startup — the most predictable moment a daemon has.
+///
+/// A stale socket left by a crashed run is removed, but only after confirming
+/// nothing is listening: removing a live one would silently steal another
+/// agent's path and leave two daemons fighting over one store.
+pub fn bind(path: &Path) -> Result<UnixListener, String> {
+    check_length(path)?;
+
+    if path.exists() {
+        if UnixStream::connect(path).is_ok() {
+            return Err(format!(
+                "another agent is already listening on {}",
+                path.display()
+            ));
+        }
+        std::fs::remove_file(path).map_err(|e| format!("removing stale socket: {e}"))?;
+    }
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("creating socket directory: {e}"))?;
+    }
+
+    let listener =
+        UnixListener::bind(path).map_err(|e| format!("binding {}: {e}", path.display()))?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .map_err(|e| format!("securing socket: {e}"))?;
+    Ok(listener)
+}
+
+/// `sockaddr_un.sun_path` is a fixed-size buffer: 104 bytes on macOS and the
+/// BSDs, 108 on Linux, including the terminating NUL.
+///
+/// This is not a limit anyone remembers, and exceeding it fails inside `bind`
+/// with "path must be shorter than SUN_LEN" -- which says nothing about which
+/// path or what to do. Since the default socket lives inside the store, a store
+/// in a deep directory makes the daemon unstartable for a reason that looks like
+/// a bug in the daemon.
+///
+/// So it is checked up front, with the number and the way out.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+const SUN_PATH_MAX: usize = 108;
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+const SUN_PATH_MAX: usize = 104;
+
+fn check_length(path: &Path) -> Result<(), String> {
+    let len = path.as_os_str().as_encoded_bytes().len();
+    if len >= SUN_PATH_MAX {
+        return Err(format!(
+            "socket path is {len} bytes; the operating system allows at most {}. \
+             Pass --socket with a shorter path, for example /tmp/daon-agent.sock. \
+             (Path was: {})",
+            SUN_PATH_MAX - 1,
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+/// Accept forever, one thread per connection.
+///
+/// Editors hold one connection at a time and requests are short, so an async
+/// runtime would be more machinery than the problem has.
+pub fn serve_forever(agent: Arc<Agent>, listener: UnixListener, now: fn() -> i64) {
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                let agent = Arc::clone(&agent);
+                std::thread::spawn(move || {
+                    if let Err(e) = serve_one(&agent, stream, now()) {
+                        eprintln!("connection error: {e}");
+                    }
+                });
+            }
+            Err(e) => eprintln!("accept failed: {e}"),
+        }
+    }
+}
+
+/// Read one request, answer it, close.
+pub fn serve_one(agent: &Agent, mut stream: UnixStream, now_ms: i64) -> std::io::Result<()> {
+    let reply = match http::Request::read(&stream) {
+        Ok(request) => agent.handle(&request, now_ms),
+        Err(http::Error::TooLarge) => {
+            Reply::err(413, "too_large", "request body exceeds the limit")
+        }
+        Err(http::Error::Malformed(what)) => Reply::err(400, "malformed", what),
+        Err(http::Error::Io(e)) => return Err(e),
+    };
+    write_reply(&mut stream, reply)
+}
+
+fn write_reply<W: Write>(w: &mut W, reply: Reply) -> std::io::Result<()> {
+    let extra: Vec<(&str, &str)> = reply
+        .headers
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    http::respond(w, reply.status, &reply.body, &extra)
+}

--- a/provenance/agentd/tests/api.rs
+++ b/provenance/agentd/tests/api.rs
@@ -1,0 +1,365 @@
+//! The editor-facing routes, exercised against a real store on disk.
+//!
+//! No socket and no keychain: the signer is a fixed test key and requests are
+//! built directly. That keeps these tests about the contract in
+//! `editor-integration-spec.md` rather than about transport.
+
+use daon_provenance_agent::policy::Limits;
+use daon_provenance_agent::witness::WitnessLog;
+use daon_provenance_agent::{Signer, Store};
+use daon_provenance_agentd::api::Agent;
+use daon_provenance_agentd::http::Request;
+use daon_provenance_core::Hash;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+/// A signer with fixed keys. Signatures are not what these tests are about.
+struct TestSigner;
+
+impl Signer for TestSigner {
+    fn author_key(&self) -> Hash {
+        [0xa1; 32]
+    }
+    fn recovery_key(&self) -> Hash {
+        [0xb2; 32]
+    }
+    fn sign(&self, _leaf_id: &Hash) -> [u8; 64] {
+        [0xcc; 64]
+    }
+}
+
+fn agent() -> (TempDir, Agent) {
+    let dir = TempDir::new().unwrap();
+    let store = Store::open(dir.path()).unwrap();
+    let witness = WitnessLog::open(dir.path()).unwrap();
+    (
+        dir,
+        Agent::new(store, witness, Box::new(TestSigner), Limits::default()),
+    )
+}
+
+fn post(agent: &Agent, path: &str, body: Value, now_ms: i64) -> (u16, Value) {
+    let raw = body.to_string();
+    let req = format!(
+        "POST {path} HTTP/1.1\r\nContent-Length: {}\r\n\r\n{raw}",
+        raw.len()
+    );
+    let parsed = Request::read(req.as_bytes()).expect("request parses");
+    let reply = agent.handle(&parsed, now_ms);
+    (
+        reply.status,
+        serde_json::from_slice(&reply.body).unwrap_or(Value::Null),
+    )
+}
+
+fn get(agent: &Agent, path: &str, now_ms: i64) -> (u16, Value) {
+    let req = format!("GET {path} HTTP/1.1\r\n\r\n");
+    let parsed = Request::read(req.as_bytes()).expect("request parses");
+    let reply = agent.handle(&parsed, now_ms);
+    (
+        reply.status,
+        serde_json::from_slice(&reply.body).unwrap_or(Value::Null),
+    )
+}
+
+fn open_session(agent: &Agent, now_ms: i64) -> String {
+    let (status, body) = post(
+        agent,
+        "/v1/session/open",
+        json!({ "tool_id": "test-editor/1.0" }),
+        now_ms,
+    );
+    assert_eq!(status, 200, "{body}");
+    body["session"].as_str().unwrap().to_string()
+}
+
+#[test]
+fn opening_a_session_returns_live_limits() {
+    let (_d, agent) = agent();
+    let (status, body) = post(
+        &agent,
+        "/v1/session/open",
+        json!({ "tool_id": "acme-editor/0.4.1" }),
+        1_000,
+    );
+
+    assert_eq!(status, 200);
+    assert!(body["session"].as_str().unwrap().starts_with("s_"));
+    // A brand new entity has no head yet.
+    assert!(body["entity_id"].is_null());
+    assert!(body["head"].is_null());
+    // The spec requires live limits so clients pace themselves rather than
+    // discovering the floor by being refused.
+    assert_eq!(body["limits"]["min_commit_interval_ms"], 2000);
+    assert_eq!(body["limits"]["daily_leaf_budget"], 2000);
+    assert_eq!(body["limits"]["leaves_remaining_today"], 2000);
+}
+
+#[test]
+fn a_tool_id_must_be_short_ascii() {
+    let (_d, agent) = agent();
+    for bad in [json!(""), json!("é-editor"), json!("x".repeat(65))] {
+        let (status, body) = post(&agent, "/v1/session/open", json!({ "tool_id": bad }), 1);
+        assert_eq!(status, 400, "accepted {bad}: {body}");
+    }
+}
+
+/// Naming an entity that does not exist must not quietly start a new chain.
+#[test]
+fn an_unknown_entity_is_refused_rather_than_created() {
+    let (_d, agent) = agent();
+    let (status, body) = post(
+        &agent,
+        "/v1/session/open",
+        json!({ "tool_id": "e/1", "entity_id": format!("sha256:{}", "11".repeat(32)) }),
+        1,
+    );
+    assert_eq!(status, 404, "{body}");
+    assert_eq!(body["error"], "unknown_entity");
+}
+
+#[test]
+fn observations_accumulate_without_committing() {
+    let (_d, agent) = agent();
+    let s = open_session(&agent, 1_000);
+
+    for i in 1..=3 {
+        let (status, body) = post(
+            &agent,
+            "/v1/observe",
+            json!({
+                "session": s,
+                "ingress": "keystroke_stream",
+                "span_bytes": { "added": 100, "removed": 2 },
+                "op_count": 40,
+                "duration_ms": 5_000
+            }),
+            1_000 + i * 10,
+        );
+        assert_eq!(status, 200);
+        assert_eq!(body["accepted"], true);
+        assert_eq!(body["pending_observations"], i);
+    }
+}
+
+/// An unrecognised ingress must not be coerced to `unknown`: that would put a
+/// claim in the log the client never made.
+#[test]
+fn an_undefined_ingress_is_refused_not_coerced() {
+    let (_d, agent) = agent();
+    let s = open_session(&agent, 1_000);
+    let (status, body) = post(
+        &agent,
+        "/v1/observe",
+        json!({
+            "session": s,
+            "ingress": "typed_by_a_human",
+            "span_bytes": { "added": 1, "removed": 0 },
+            "op_count": 1,
+            "duration_ms": 1
+        }),
+        1_100,
+    );
+    assert_eq!(status, 400);
+    assert_eq!(body["error"], "bad_ingress");
+}
+
+#[test]
+fn explicit_commits_produce_a_leaf() {
+    let (_d, agent) = agent();
+    let s = open_session(&agent, 1_000);
+    post(
+        &agent,
+        "/v1/observe",
+        json!({ "session": s, "ingress": "keystroke_stream",
+                "span_bytes": { "added": 200, "removed": 5 },
+                "op_count": 90, "duration_ms": 30_000 }),
+        1_100,
+    );
+
+    let (status, body) = post(
+        &agent,
+        "/v1/commit",
+        json!({ "session": s, "content": "the manuscript", "reason": "explicit" }),
+        60_000,
+    );
+    assert_eq!(status, 200, "{body}");
+    assert_eq!(body["committed"], true);
+    assert_eq!(body["seq"], 0, "genesis");
+    assert!(body["entity_id"].as_str().unwrap().starts_with("sha256:"));
+}
+
+/// Coalescing is not an error, and the spec says so explicitly.
+#[test]
+fn an_idle_commit_coalesces_rather_than_failing() {
+    let (_d, agent) = agent();
+    let s = open_session(&agent, 1_000);
+    post(
+        &agent,
+        "/v1/observe",
+        json!({ "session": s, "ingress": "keystroke_stream",
+                "span_bytes": { "added": 10, "removed": 0 },
+                "op_count": 5, "duration_ms": 1_000 }),
+        1_100,
+    );
+
+    let (status, body) = post(
+        &agent,
+        "/v1/commit",
+        json!({ "session": s, "content": "draft", "reason": "idle" }),
+        1_200,
+    );
+    assert_eq!(status, 200, "coalescing must not be an error status");
+    assert_eq!(body["committed"], false);
+    assert_eq!(body["reason"], "coalesced");
+    assert!(body["retry_after_ms"].as_u64().unwrap() > 0);
+}
+
+/// `explicit` bypasses coalescing but not the rate floor.
+#[test]
+fn explicit_does_not_bypass_the_rate_floor() {
+    let (_d, agent) = agent();
+    let s = open_session(&agent, 1_000);
+
+    let observe = |now| {
+        post(
+            &agent,
+            "/v1/observe",
+            json!({ "session": s, "ingress": "paste",
+                    "span_bytes": { "added": 50, "removed": 0 },
+                    "op_count": 1, "duration_ms": 10 }),
+            now,
+        )
+    };
+
+    observe(1_100);
+    let (_, first) = post(
+        &agent,
+        "/v1/commit",
+        json!({ "session": s, "content": "a", "reason": "explicit" }),
+        2_000,
+    );
+    assert_eq!(first["committed"], true);
+
+    observe(2_100);
+    let (status, second) = post(
+        &agent,
+        "/v1/commit",
+        json!({ "session": s, "content": "ab", "reason": "explicit" }),
+        2_200,
+    );
+    assert_eq!(status, 200);
+    assert_eq!(second["committed"], false, "inside the 2s floor");
+    assert_eq!(second["reason"], "rate_limited");
+}
+
+#[test]
+fn a_leaf_needs_at_least_one_observation() {
+    let (_d, agent) = agent();
+    let s = open_session(&agent, 1_000);
+    let (status, body) = post(
+        &agent,
+        "/v1/commit",
+        json!({ "session": s, "content": "nothing was observed", "reason": "explicit" }),
+        60_000,
+    );
+    assert_eq!(status, 400, "{body}");
+    assert_eq!(body["error"], "no_observations");
+}
+
+/// A second commit in the same session continues the chain rather than starting
+/// a new entity -- the session learns its entity id at genesis.
+#[test]
+fn a_session_continues_its_entity_after_genesis() {
+    let (_d, agent) = agent();
+    let s = open_session(&agent, 1_000);
+
+    let mut entity = String::new();
+    for (i, now) in [10_000i64, 100_000, 200_000].into_iter().enumerate() {
+        post(
+            &agent,
+            "/v1/observe",
+            json!({ "session": s, "ingress": "keystroke_stream",
+                    "span_bytes": { "added": 30, "removed": 1 },
+                    "op_count": 12, "duration_ms": 4_000 }),
+            now - 500,
+        );
+        let (status, body) = post(
+            &agent,
+            "/v1/commit",
+            json!({ "session": s, "content": format!("draft {i}"), "reason": "explicit" }),
+            now,
+        );
+        assert_eq!(status, 200, "{body}");
+        assert_eq!(body["committed"], true);
+        assert_eq!(body["seq"], i as u64);
+        if entity.is_empty() {
+            entity = body["entity_id"].as_str().unwrap().to_string();
+        } else {
+            assert_eq!(body["entity_id"], entity, "forked to a new entity");
+        }
+    }
+}
+
+/// A freshly committed head is unwitnessed, and that is normal rather than an
+/// error. The spec is explicit that clients must expect it.
+#[test]
+fn a_proof_is_pending_until_the_head_is_witnessed() {
+    let (_d, agent) = agent();
+    let s = open_session(&agent, 1_000);
+    post(
+        &agent,
+        "/v1/observe",
+        json!({ "session": s, "ingress": "import",
+                "span_bytes": { "added": 900, "removed": 0 },
+                "op_count": 1, "duration_ms": 50 }),
+        1_100,
+    );
+    let (_, commit) = post(
+        &agent,
+        "/v1/commit",
+        json!({ "session": s, "content": "imported text", "reason": "explicit" }),
+        60_000,
+    );
+    let entity = commit["entity_id"].as_str().unwrap();
+
+    let (status, body) = get(&agent, &format!("/v1/entity/{entity}/proof?seq=0"), 61_000);
+    assert_eq!(status, 200, "{body}");
+    assert_eq!(body["witness_state"], "pending");
+    assert!(body["witness_receipt"].is_null());
+    assert_eq!(body["seq"], 0);
+    // 218-byte leaf body, hex encoded.
+    assert_eq!(body["leaf"].as_str().unwrap().len(), 218 * 2);
+}
+
+#[test]
+fn unknown_routes_and_sessions_are_refused() {
+    let (_d, agent) = agent();
+    assert_eq!(post(&agent, "/v1/nope", json!({}), 1).0, 404);
+    assert_eq!(
+        post(
+            &agent,
+            "/v1/observe",
+            json!({
+            "session": "s_does_not_exist", "ingress": "unknown",
+            "span_bytes": { "added": 1, "removed": 0 },
+            "op_count": 1, "duration_ms": 1 }),
+            1
+        )
+        .0,
+        404
+    );
+}
+
+#[test]
+fn a_malformed_body_is_a_client_error() {
+    let (_d, agent) = agent();
+    let raw = "{not json";
+    let req = format!(
+        "POST /v1/session/open HTTP/1.1\r\nContent-Length: {}\r\n\r\n{raw}",
+        raw.len()
+    );
+    let parsed = Request::read(req.as_bytes()).unwrap();
+    let reply = agent.handle(&parsed, 1);
+    assert_eq!(reply.status, 400);
+}

--- a/provenance/agentd/tests/http.rs
+++ b/provenance/agentd/tests/http.rs
@@ -1,0 +1,101 @@
+//! The hand-rolled HTTP subset: what it accepts, and what it must refuse.
+
+use daon_provenance_agentd::http::{respond, Error, Request, MAX_BODY};
+
+fn parse(raw: &str) -> Result<Request, Error> {
+    Request::read(raw.as_bytes())
+}
+
+#[test]
+fn parses_a_post_with_a_body() {
+    let r = parse("POST /v1/commit HTTP/1.1\r\nContent-Length: 7\r\n\r\n{\"a\":1}").unwrap();
+    assert_eq!(r.method, "POST");
+    assert_eq!(r.path, "/v1/commit");
+    assert_eq!(r.body, b"{\"a\":1}");
+}
+
+#[test]
+fn splits_the_query_string_off_the_path() {
+    let r = parse("GET /v1/entity/abc/proof?seq=42 HTTP/1.1\r\n\r\n").unwrap();
+    assert_eq!(r.path, "/v1/entity/abc/proof");
+    assert_eq!(r.query.get("seq").map(String::as_str), Some("42"));
+}
+
+#[test]
+fn decodes_percent_escapes_and_plus() {
+    let r = parse("GET /x?a=one%20two&b=three+four HTTP/1.1\r\n\r\n").unwrap();
+    assert_eq!(r.query["a"], "one two");
+    assert_eq!(r.query["b"], "three four");
+}
+
+#[test]
+fn headers_are_case_insensitive() {
+    let r = parse("POST /x HTTP/1.1\r\nCONTENT-LENGTH: 2\r\n\r\nhi").unwrap();
+    assert_eq!(r.body, b"hi");
+}
+
+/// No Content-Length means no body. A body without one would need chunked
+/// decoding, which is not implemented and must not be guessed at.
+#[test]
+fn a_missing_length_means_an_empty_body() {
+    let r = parse("GET /v1/thing HTTP/1.1\r\n\r\n").unwrap();
+    assert!(r.body.is_empty());
+}
+
+#[test]
+fn refuses_an_oversized_body() {
+    let raw = format!(
+        "POST /x HTTP/1.1\r\nContent-Length: {}\r\n\r\n",
+        MAX_BODY + 1
+    );
+    assert!(matches!(parse(&raw), Err(Error::TooLarge)));
+}
+
+/// A length prefix is client-controlled and must not be able to make the daemon
+/// allocate arbitrarily before any body has arrived.
+#[test]
+fn refuses_an_absurd_length() {
+    let raw = "POST /x HTTP/1.1\r\nContent-Length: 99999999999999999999\r\n\r\n";
+    assert!(matches!(parse(raw), Err(Error::Malformed(_))));
+}
+
+#[test]
+fn refuses_junk_and_truncation() {
+    assert!(parse("not http at all\r\n\r\n").is_err());
+    assert!(matches!(
+        parse("POST /x HTTP/1.1\r\nContent-Length: 100\r\n\r\nshort"),
+        Err(Error::Io(_))
+    ));
+    assert!(matches!(
+        parse("POST /x HTTP/1.1\r\nnocolon\r\n\r\n"),
+        Err(Error::Malformed(_))
+    ));
+}
+
+#[test]
+fn refuses_absurd_headers() {
+    let big = "x-pad: ".to_string() + &"a".repeat(32 * 1024);
+    let raw = format!("GET /x HTTP/1.1\r\n{big}\r\n\r\n");
+    assert!(matches!(parse(&raw), Err(Error::Malformed(_))));
+}
+
+#[test]
+fn responses_carry_a_length_and_close() {
+    let mut out = Vec::new();
+    respond(&mut out, 200, b"{\"ok\":true}", &[]).unwrap();
+    let text = String::from_utf8(out).unwrap();
+    assert!(text.starts_with("HTTP/1.1 200 OK\r\n"));
+    assert!(text.contains("Content-Type: application/json\r\n"));
+    assert!(text.contains("Content-Length: 11\r\n"));
+    assert!(text.contains("Connection: close\r\n"));
+    assert!(text.ends_with("\r\n\r\n{\"ok\":true}"));
+}
+
+#[test]
+fn extra_headers_are_emitted() {
+    let mut out = Vec::new();
+    respond(&mut out, 429, b"{}", &[("Retry-After", "60")]).unwrap();
+    assert!(String::from_utf8(out)
+        .unwrap()
+        .contains("Retry-After: 60\r\n"));
+}

--- a/provenance/agentd/tests/socket.rs
+++ b/provenance/agentd/tests/socket.rs
@@ -1,0 +1,184 @@
+//! The daemon over a real Unix socket.
+//!
+//! These are the parts the route tests cannot cover: that the socket is created
+//! with the permissions the spec requires, that a real HTTP exchange completes
+//! over it, and that two daemons cannot fight over one path.
+
+use std::io::{Read, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::UnixStream;
+use std::sync::Arc;
+
+use daon_provenance_agent::policy::Limits;
+use daon_provenance_agent::witness::WitnessLog;
+use daon_provenance_agent::{Signer, Store};
+use daon_provenance_agentd::{api::Agent, server};
+use daon_provenance_core::Hash;
+use tempfile::TempDir;
+
+struct TestSigner;
+impl Signer for TestSigner {
+    fn author_key(&self) -> Hash {
+        [0xa1; 32]
+    }
+    fn recovery_key(&self) -> Hash {
+        [0xb2; 32]
+    }
+    fn sign(&self, _: &Hash) -> [u8; 64] {
+        [0xcc; 64]
+    }
+}
+
+fn running() -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().unwrap();
+    let sock = dir.path().join("agent.sock");
+
+    let store = Store::open(dir.path()).unwrap();
+    let witness = WitnessLog::open(dir.path()).unwrap();
+    let agent = Arc::new(Agent::new(
+        store,
+        witness,
+        Box::new(TestSigner),
+        Limits::default(),
+    ));
+
+    let listener = server::bind(&sock).expect("bind");
+    std::thread::spawn(move || server::serve_forever(agent, listener, || 1_000_000));
+    (dir, sock)
+}
+
+/// One request over the socket, returning the raw response.
+fn request(sock: &std::path::Path, raw: &str) -> String {
+    let mut stream = UnixStream::connect(sock).expect("connect");
+    stream.write_all(raw.as_bytes()).unwrap();
+    stream.flush().unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+    response
+}
+
+/// The spec requires mode 0600. This is the check that would otherwise only
+/// fail in the field, on a machine with a permissive umask.
+#[test]
+fn the_socket_is_only_readable_by_its_owner() {
+    let (_dir, sock) = running();
+    let mode = std::fs::metadata(&sock).unwrap().permissions().mode();
+    assert_eq!(
+        mode & 0o777,
+        0o600,
+        "socket mode was {:o}, expected 600",
+        mode & 0o777
+    );
+}
+
+#[test]
+fn a_real_request_gets_a_real_response() {
+    let (_dir, sock) = running();
+    let body = r#"{"tool_id":"socket-test/1.0"}"#;
+    let response = request(
+        &sock,
+        &format!(
+            "POST /v1/session/open HTTP/1.1\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        ),
+    );
+
+    assert!(response.starts_with("HTTP/1.1 200 OK\r\n"), "{response}");
+    assert!(response.contains("Content-Type: application/json\r\n"));
+    let json = response.split("\r\n\r\n").nth(1).expect("body");
+    let parsed: serde_json::Value = serde_json::from_str(json).expect("json body");
+    assert!(parsed["session"].as_str().unwrap().starts_with("s_"));
+}
+
+/// A full session over the socket: open, observe, commit, then read the proof
+/// back. This is the flow an editor performs.
+#[test]
+fn an_editor_can_complete_a_session() {
+    let (_dir, sock) = running();
+
+    let post = |path: &str, body: String| -> serde_json::Value {
+        let raw = format!(
+            "POST {path} HTTP/1.1\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let response = request(&sock, &raw);
+        serde_json::from_str(response.split("\r\n\r\n").nth(1).unwrap()).unwrap()
+    };
+
+    let session = post(
+        "/v1/session/open",
+        r#"{"tool_id":"socket-test/1.0"}"#.to_string(),
+    )["session"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let observed = post(
+        "/v1/observe",
+        format!(
+            r#"{{"session":"{session}","ingress":"keystroke_stream",
+                 "span_bytes":{{"added":300,"removed":10}},
+                 "op_count":120,"duration_ms":45000}}"#
+        ),
+    );
+    assert_eq!(observed["accepted"], true);
+
+    let committed = post(
+        "/v1/commit",
+        format!(r#"{{"session":"{session}","content":"a manuscript","reason":"explicit"}}"#),
+    );
+    assert_eq!(committed["committed"], true, "{committed}");
+    let entity = committed["entity_id"].as_str().unwrap();
+
+    let raw = format!("GET /v1/entity/{entity}/proof?seq=0 HTTP/1.1\r\n\r\n");
+    let response = request(&sock, &raw);
+    let proof: serde_json::Value =
+        serde_json::from_str(response.split("\r\n\r\n").nth(1).unwrap()).unwrap();
+
+    assert_eq!(proof["seq"], 0);
+    assert_eq!(proof["witness_state"], "pending", "not yet anchored");
+    assert_eq!(proof["leaf"].as_str().unwrap().len(), 218 * 2);
+}
+
+/// Binding over a live agent must fail rather than stealing its path and
+/// leaving two daemons on one store.
+#[test]
+fn a_second_agent_refuses_to_steal_the_socket() {
+    let (_dir, sock) = running();
+    match server::bind(&sock) {
+        Err(e) => assert!(e.contains("already listening"), "wrong error: {e}"),
+        Ok(_) => panic!("bound over a live socket"),
+    }
+}
+
+/// A leftover socket from a crashed run must not block startup forever.
+#[test]
+fn a_stale_socket_is_reclaimed() {
+    let dir = TempDir::new().unwrap();
+    let sock = dir.path().join("agent.sock");
+
+    // Bind and drop: the file stays behind with nothing listening.
+    drop(server::bind(&sock).expect("first bind"));
+    assert!(sock.exists(), "socket file should remain");
+
+    server::bind(&sock).expect("stale socket should be reclaimed");
+}
+
+#[test]
+fn a_malformed_request_gets_a_400_not_a_hang() {
+    let (_dir, sock) = running();
+    let response = request(&sock, "GARBAGE\r\n\r\n");
+    assert!(response.starts_with("HTTP/1.1 400"), "{response}");
+}
+
+/// A socket path longer than `sun_path` must fail with something actionable
+/// rather than the operating system's "path must be shorter than SUN_LEN",
+/// which names neither the path nor the remedy.
+#[test]
+fn an_over_long_socket_path_explains_itself() {
+    let dir = TempDir::new().unwrap();
+    let deep = dir.path().join("a".repeat(120));
+    let err = server::bind(&deep).expect_err("should refuse");
+    assert!(err.contains("--socket"), "unhelpful error: {err}");
+    assert!(err.contains("bytes"), "no length in error: {err}");
+}


### PR DESCRIPTION
Until now: four library crates and a spec describing a server nobody had written. An editor team would get `.rlib` files and a document. This writes the daemon.

`daon-provenance-agentd --store PATH [--socket PATH] [--identity NAME]` binds a Unix socket and serves the routes in `editor-integration-spec.md` §3.

> The content-hashing and document-format work that was originally on this branch moved to **#115**. This is the Rust half only.

## Transport

Follows the spec exactly, including the part that erodes: **Unix domain socket, mode `0600`, and no `--port` flag at all.** The spec's reasoning is *"a debug flag that opens a port is a debug flag that ships"* — so adding one later means arguing with the spec, not adding a convenience. Permissions are applied immediately after bind, since a permissive umask would leave the socket world-connectable during startup.

**HTTP hand-rolled, JSON not.** The usual case for a real HTTP stack is that parsing faces the internet; this never does. So it parses the strict subset the spec needs — no chunked encoding, no keep-alive, one request per connection — and refuses the rest. JSON is the opposite judgement: attacker-shaped input with subtle failures, so `serde_json`.

## The routes keep the spec's promises

- Live limits at session open, so clients pace themselves rather than discovering the floor by being refused.
- **Coalescing returns `200` with `committed:false`** — the spec says an editor treating it as an error has misread the contract.
- `explicit` bypasses coalescing but **not** the rate floor.
- An unrecognised `ingress` is refused, not mapped to `unknown` — substituting it would put a claim in the log the client never made.
- Naming a missing entity is `404`, not a silent genesis. Creating a fresh chain because a lookup failed would fork history exactly when someone thought they were continuing it.
- A fresh head reports `witness_state: "pending"` rather than erroring. That's normal for hours.

## Two bugs found by running it, not testing it

**Socket path length.** `sockaddr_un.sun_path` caps at 104 bytes on macOS, 108 on Linux — and the default socket lives inside the store, so a deep store path makes the daemon unstartable with `path must be shorter than SUN_LEN`, naming neither the path nor the remedy. Now checked up front with the length, the limit, and the flag to use.

**Junk request lines** parsed as a method and path, rejected later by the router reporting the wrong problem. The version token is now required.

## A latent bug the new CI caught

The keychain feature had been **broken on Linux and Windows** since the protected-store change. Dropping the `keyring` v1 shim removed what registered a platform store on those targets, so `keyring_core::Entry` would fail with `NoDefaultStore` at runtime — every credential operation.

Nothing caught it because the keychain tests are `#[ignore]`d and the job only ran `cargo check`, **which compiles a store that is never registered perfectly happily.** Windows Credential Manager and Linux Secret Service are now registered explicitly.

Adding the Linux job then surfaced two more on its first runs: `secret-service` refuses to compile without a runtime feature chosen (a `compile_error!`, not a default), and the wasm32 step was building the whole workspace, which only ever worked while nothing in it needed randomness.

## CI

A `macos-latest` job runs the `#[ignore]`d keychain tests against a keychain it creates for the purpose — throwaway, made default for the job, deleted after, so the runner's login keychain is neither unlocked nor written to. Verified locally against a disposable keychain first.

What CI **cannot** test is the protected store: that needs a signed app with a provisioning profile, so an unsigned runner will always report `FileKeychain`. A real limit, not a gap to close.

## A packaging finding

`keystore::init` probes each store with a real write, so macOS prompts on **every process start** — and "Always Allow" doesn't help, because that grant is bound to the binary's exact code signature and `cargo` re-signs ad-hoc every build. Every rebuild looks like a different app.

Same wall as iCloud sync, same fix, but it bites *regardless of entitlements*: an agent that interrogates the creator at every launch won't be run twice. Documented in `keystore.rs`.

## Also: the recovery-key decision

`key-recovery.md`'s last open question is settled. The author key may name a new recovery key, effective only after N witnessed heads.

Each key may replace the other; **neither may replace itself.** The half that isn't new is worth stating, because symmetry with transfer suggests the opposite and would quietly destroy counter-rotation: a recovery-signed rotation must *not* replace the recovery key, or a thief who obtained it installs their own on first use and §4's defence has nothing left to act with.

Delay is right here though immediate was right for author-key rotation — an immediate rule would make a stolen author key strictly more dangerous than today. It costs the minimum verifier nothing; rotation legitimacy was always an audit question.

## Tests

117 across the workspace, 30 new: routes against a real store, the HTTP subset including oversized and malformed input, and the daemon over an **actual socket** — created `0600`, a full session completing, a second agent refusing to steal a live socket, a stale one reclaimed.

Verified by hand against a live daemon with `curl --unix-socket`: open → observe → commit → read the proof back.

## Still not here

- **Calendar submission and block headers** — transport outward, the last thing between a committed head and a real Bitcoin anchor.
- **Rotation and transfer leaves** — now unblocked by the decision above; still need N chosen and the leaf encoding settled.