### PR TITLE
fix(content): hash the words, not the HTML they arrived in

### DIFF
--- a/api-server/src/server.ts
+++ b/api-server/src/server.ts
@@ -8,7 +8,7 @@
  */
 
 import express from 'express';
-import { toPlainText } from './utils/content-canonical';
+import { toPlainText } from './utils/content-canonical.js';
 import cors from 'cors';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';

--- a/api-server/src/server.ts
+++ b/api-server/src/server.ts
@@ -228,6 +228,24 @@ function generateContentHash(content) {
   return crypto.createHash('sha256').update(text, 'utf8').digest('hex');
 }
 
+/**
+ * How content was hashed before canonicalisation existed: raw bytes, markup and
+ * CRLF included.
+ *
+ * Needed on the **verify** path only, and permanently. Content is never stored —
+ * `protected_content` holds a hash and no body — so there is no way to tell which
+ * existing registrations were made over HTML or CRLF, and therefore no migration
+ * that could fix them. A creator who registered before the change and submits the
+ * same content today would otherwise be told it was never registered, which is
+ * the one answer this system must not give wrongly.
+ *
+ * Never used for new registrations. It only ever widens what verification
+ * accepts.
+ */
+function generateLegacyContentHash(content) {
+  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
 function generateVerificationUrl(contentHash) {
   const baseUrl = process.env.VERIFICATION_BASE_URL || 'https://verify.daon.network';
   return `${baseUrl}/verify/sha256:${contentHash}`;
@@ -745,16 +763,26 @@ app.post('/api/v1/verify-content', [
     // that is registered, which is the worst possible failure here.
     const contentHash = generateContentHash(content);
 
+    // Registrations predating canonicalisation committed to the raw bytes. Since
+    // content is not stored, they cannot be identified or migrated, so both are
+    // accepted here and the canonical one is tried first.
+    const legacyHash = generateLegacyContentHash(content);
+    const candidateHashes =
+      legacyHash === contentHash ? [contentHash] : [contentHash, legacyHash];
+
     let record = null;
     let source = 'memory';
+    let matchedHash = contentHash;
 
     // Try blockchain first if enabled
     if (blockchainEnabled && blockchainClient.connected) {
+      for (const candidate of candidateHashes) {
       try {
-        const blockchainRecord = await blockchainClient.verifyContent(contentHash);
+        const blockchainRecord = await blockchainClient.verifyContent(candidate);
         if (blockchainRecord.verified) {
+          matchedHash = candidate;
           record = {
-            contentHash,
+            contentHash: candidate,
             timestamp: new Date(blockchainRecord.timestamp * 1000).toISOString(),
             license: blockchainRecord.license,
             creator: blockchainRecord.creator,
@@ -766,38 +794,56 @@ app.post('/api/v1/verify-content', [
       } catch (blockchainError) {
         logger.warn('Blockchain verify-content failed, checking memory:', blockchainError.message);
       }
+      if (record) break;
+      }
     }
 
     // Fall back to in-memory cache
     if (!record) {
-      record = protectedContent.get(contentHash);
+      for (const candidate of candidateHashes) {
+        record = protectedContent.get(candidate);
+        if (record) { matchedHash = candidate; break; }
+      }
       if (record) {
         source = 'memory-cache';
       }
     }
 
-    // Fall back to database
+    // Fall back to database. This is the path that matters most for
+    // registrations predating canonicalisation, which is why it tries both.
     if (!record) {
-      try {
-        const dbRecord = await db.content.findByHash(contentHash);
-        if (dbRecord) {
-          record = {
-            contentHash,
-            timestamp: dbRecord.created_at,
-            license: dbRecord.license,
-            metadata: {
-              title: dbRecord.title,
-              type: dbRecord.content_type,
-              description: dbRecord.description,
-            },
-            verificationUrl: dbRecord.verification_url || generateVerificationUrl(contentHash),
-            blockchainTx: dbRecord.blockchain_tx,
-          };
-          source = 'database';
+      for (const candidate of candidateHashes) {
+        try {
+          const dbRecord = await db.content.findByHash(candidate);
+          if (dbRecord) {
+            matchedHash = candidate;
+            record = {
+              contentHash: candidate,
+              timestamp: dbRecord.created_at,
+              license: dbRecord.license,
+              metadata: {
+                title: dbRecord.title,
+                type: dbRecord.content_type,
+                description: dbRecord.description,
+              },
+              verificationUrl:
+                dbRecord.verification_url || generateVerificationUrl(candidate),
+              blockchainTx: dbRecord.blockchain_tx,
+            };
+            source = 'database';
+            break;
+          }
+        } catch (dbError) {
+          logger.warn('DB verify-content lookup failed:', (dbError as any).message);
         }
-      } catch (dbError) {
-        logger.warn('DB verify-content lookup failed:', (dbError as any).message);
       }
+    }
+
+    // A match on the legacy hash is worth knowing about: it says the creator is
+    // holding content that predates canonicalisation, and it is the only signal
+    // that would ever tell us how much of that exists.
+    if (record && matchedHash !== contentHash) {
+      logger.info('verify-content matched a pre-canonicalisation hash');
     }
 
     if (!record) {

--- a/api-server/src/server.ts
+++ b/api-server/src/server.ts
@@ -8,6 +8,7 @@
  */
 
 import express from 'express';
+import { toPlainText } from './utils/content-canonical';
 import cors from 'cors';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
@@ -208,8 +209,23 @@ const handleValidationErrors = (req, res, next) => {
 };
 
 // Utility functions
+
+/**
+ * The content hash for a registration.
+ *
+ * Markup is removed first, so the hash commits to the words rather than to the
+ * HTML they arrived in. Without this, the same paragraph submitted through the
+ * WordPress plugin and through the API produces two different hashes, and a
+ * theme or block-editor change silently breaks a registration the creator never
+ * touched. See utils/content-canonical.ts and
+ * docs/design/document-formats.md.
+ *
+ * Plain-text input is unchanged, so hashes registered before this behaviour
+ * existed still match.
+ */
 function generateContentHash(content) {
-  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+  const { text } = toPlainText(content);
+  return crypto.createHash('sha256').update(text, 'utf8').digest('hex');
 }
 
 function generateVerificationUrl(contentHash) {
@@ -724,8 +740,10 @@ app.post('/api/v1/verify-content', [
   try {
     const { content } = req.body;
 
-    // Compute SHA-256 of the submitted content (same algorithm as /protect)
-    const contentHash = crypto.createHash('sha256').update(content).digest('hex');
+    // Must go through the same function as /protect, not a second inline copy:
+    // a verify path that hashes differently reports "not registered" for content
+    // that is registered, which is the worst possible failure here.
+    const contentHash = generateContentHash(content);
 
     let record = null;
     let source = 'memory';

--- a/api-server/src/test/content-canonical.test.ts
+++ b/api-server/src/test/content-canonical.test.ts
@@ -1,0 +1,154 @@
+/**
+ * What gets hashed when content is registered.
+ *
+ * The contract these protect: the words are hashed, the markup is not, and
+ * whitespace the creator wrote survives untouched.
+ */
+import { toPlainText } from '../utils/content-canonical.js';
+
+describe('toPlainText', () => {
+  describe('leaves plain text alone', () => {
+    it('returns prose byte-identical', () => {
+      const prose = 'It was the best of times, it was the worst of times.';
+      expect(toPlainText(prose)).toEqual({ text: prose, stripped: false });
+    });
+
+    // The reason registrations made before stripping existed still verify.
+    it('does not alter content that has no markup', () => {
+      const original = 'Line one\n\n\n\nLine two   with   spacing\n\tand a tab\n';
+      const { text, stripped } = toPlainText(original);
+      expect(stripped).toBe(false);
+      expect(text).toBe(original);
+    });
+
+    // Prose containing < and > is not markup, and treating it as such would
+    // change a hash the creator never asked to change.
+    it('does not mistake comparisons for tags', () => {
+      const maths = 'if a < b and c > d then the set is 3 < x > 1';
+      expect(toPlainText(maths).stripped).toBe(false);
+    });
+  });
+
+  describe('strips markup', () => {
+    it('removes tags but keeps the words', () => {
+      const { text, stripped } = toPlainText('<p>Hello <em>world</em></p>');
+      expect(stripped).toBe(true);
+      expect(text).toBe('Hello world');
+    });
+
+    it('keeps paragraphs apart rather than running them together', () => {
+      const { text } = toPlainText('<p>First</p><p>Second</p>');
+      expect(text).toBe('First\n\nSecond');
+      expect(text).not.toContain('FirstSecond');
+    });
+
+    it('turns line breaks into newlines', () => {
+      expect(toPlainText('one<br>two<br/>three').text).toBe('one\ntwo\nthree');
+    });
+
+    it('drops script and style contents entirely', () => {
+      const { text } = toPlainText(
+        '<p>Real words</p><script>alert("x")</script><style>p{color:red}</style>'
+      );
+      expect(text).toBe('Real words');
+      expect(text).not.toContain('alert');
+      expect(text).not.toContain('color');
+    });
+
+    it('drops comments, which no reader ever saw', () => {
+      expect(toPlainText('<p>Visible<!-- hidden note --></p>').text).toBe('Visible');
+    });
+
+    it('decodes the predefined entities', () => {
+      const { text } = toPlainText('<p>Tom &amp; Jerry &lt;3 &quot;quotes&quot;</p>');
+      expect(text).toBe('Tom & Jerry <3 "quotes"');
+    });
+
+    it('decodes numeric entities', () => {
+      expect(toPlainText('<p>caf&#233; and &#x2014; dash</p>').text).toBe('café and — dash');
+    });
+
+    // The HTML entity table is a moving target; an unknown name in a manuscript
+    // is text, not something to guess at.
+    it('leaves unknown entities as written', () => {
+      expect(toPlainText('<p>&notarealentity; stays</p>').text).toBe('&notarealentity; stays');
+    });
+
+    it('does not emit unpaired surrogates', () => {
+      const { text } = toPlainText('<p>&#xD800;</p>');
+      expect(text).toBe('&#xD800;');
+    });
+  });
+
+  describe('does not collapse whitespace', () => {
+    // Spacing is content in poetry, concrete verse and code samples.
+    // Collapsing it would make different works hash identically.
+    it('preserves indentation inside markup', () => {
+      const { text } = toPlainText('<pre>    indented\n        further</pre>');
+      expect(text).toContain('    indented');
+      expect(text).toContain('        further');
+    });
+
+    it('preserves runs of spaces the creator wrote', () => {
+      const { text } = toPlainText('<p>word     word</p>');
+      expect(text).toBe('word     word');
+    });
+
+    it('preserves single and double newlines', () => {
+      const { text } = toPlainText('<div>a\nb\n\nc</div>');
+      expect(text).toContain('a\nb\n\nc');
+    });
+  });
+
+  describe('the reason this exists', () => {
+    // The same paragraph through WordPress and through the API must produce one
+    // hash. Before stripping, these were two different registrations.
+    it('gives the same text for the same words in different markup', () => {
+      const fromWordpress =
+        '<!-- wp:paragraph --><p class="has-text-align-left">The same words.</p><!-- /wp:paragraph -->';
+      const fromEditor = '<div><span style="font-weight:400">The same words.</span></div>';
+      const typed = 'The same words.';
+
+      expect(toPlainText(fromWordpress).text).toBe(typed);
+      expect(toPlainText(fromEditor).text).toBe(typed);
+    });
+
+    // A theme change or block-editor upgrade rewrites attributes. The words did
+    // not change, so the hash must not either.
+    it('is unaffected by attribute churn', () => {
+      const before = '<p class="entry" data-block="a1">Unchanged prose</p>';
+      const after = '<p class="entry wp-block-paragraph" data-block="b2" dir="ltr">Unchanged prose</p>';
+      expect(toPlainText(before).text).toBe(toPlainText(after).text);
+    });
+  });
+
+  it('rejects non-strings rather than hashing "[object Object]"', () => {
+    expect(() => toPlainText({} as unknown as string)).toThrow(TypeError);
+  });
+});
+
+describe('line endings', () => {
+  // A line ending is whatever the author's editor emitted. Nobody chooses CRLF,
+  // so the same text from Windows and from a Mac must hash the same -- unlike
+  // spacing within a line, which is authorial and is left alone.
+  it('normalises CRLF and CR to LF', () => {
+    const lf = 'first line\nsecond line';
+    expect(toPlainText('first line\r\nsecond line').text).toBe(lf);
+    expect(toPlainText('first line\rsecond line').text).toBe(lf);
+  });
+
+  it('gives one result for mixed endings', () => {
+    const mixed = 'a\r\nb\rc\nd';
+    expect(toPlainText(mixed).text).toBe('a\nb\nc\nd');
+  });
+
+  it('normalises endings even with no markup present', () => {
+    const { text, stripped } = toPlainText('plain\r\ntext');
+    expect(stripped).toBe(false);
+    expect(text).toBe('plain\ntext');
+  });
+
+  it('still leaves intra-line spacing alone', () => {
+    expect(toPlainText('a    b\r\n    indented').text).toBe('a    b\n    indented');
+  });
+});

--- a/api-server/src/utils/content-canonical.ts
+++ b/api-server/src/utils/content-canonical.ts
@@ -1,0 +1,130 @@
+/**
+ * What DAON hashes when it registers content.
+ *
+ * The rule, from `docs/design/document-formats.md`: **register the words, not
+ * the markup they arrived in.** A creator who publishes the same paragraph
+ * through WordPress, a browser extension and the API should get one hash, and
+ * they will not if one of those sends `<p>` tags and another does not.
+ *
+ * Hashing HTML also makes the hash depend on things the creator never chose —
+ * a theme change, a block editor upgrade, a plugin that rewrites attributes —
+ * so a registration silently stops matching its own content.
+ *
+ * # Deliberately minimal
+ *
+ * Tags are removed, entities decoded, and line endings normalised to LF.
+ * **Intra-line whitespace is not touched.**
+ *
+ * The line between those two is deliberate. A line ending is a platform artifact
+ * — nobody chooses CRLF, it is whatever their editor emitted — so the same text
+ * typed on Windows and on a Mac must hash the same. Spacing *within* a line is
+ * authorial: it is the shape of a poem, the indentation of a code sample, the
+ * layout of concrete verse. Collapsing it would make genuinely different works
+ * hash identically, and for output used in disputes a false match is far worse
+ * than a missed one.
+ *
+ * # Effect on existing registrations
+ *
+ * Plain-text input with LF endings is returned **byte-identical**, so most
+ * existing registrations are unaffected.
+ *
+ * Two groups do change, both deliberately. Content registered as HTML now hashes
+ * to its words, which is the point. And plain text containing CRLF now hashes as
+ * LF — worth checking against the existing table before this ships, because
+ * those registrations were made against the raw bytes.
+ */
+
+/** Content as submitted, and what was actually hashed. */
+export interface CanonicalContent {
+  /** The exact text the hash commits to. */
+  text: string;
+  /** Whether markup was removed to produce it. */
+  stripped: boolean;
+}
+
+/**
+ * Does this look like markup rather than prose that merely contains `<`?
+ *
+ * Requires a plausible tag name after `<`, so `a < b and c > d` is left alone.
+ * Being conservative matters more than being thorough here: wrongly stripping
+ * changes a hash the creator did not expect to change, while wrongly keeping
+ * markup produces a hash that is merely no better than today's.
+ */
+function looksLikeMarkup(content: string): boolean {
+  return /<\/?[a-zA-Z][a-zA-Z0-9-]*(\s[^<>]*)?\/?>/.test(content);
+}
+
+/** The five XML predefined entities, plus the numeric forms. */
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&(#\d+|#[xX][0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);/g, (match, body: string) => {
+      if (body.startsWith('#')) {
+        const code = body[1] === 'x' || body[1] === 'X'
+          ? parseInt(body.slice(2), 16)
+          : parseInt(body.slice(1), 10);
+        // Reject anything outside Unicode, and surrogates, which would produce
+        // an unpaired code unit and a string that cannot round-trip.
+        if (!Number.isFinite(code) || code < 0 || code > 0x10ffff) return match;
+        if (code >= 0xd800 && code <= 0xdfff) return match;
+        return String.fromCodePoint(code);
+      }
+      const named: Record<string, string> = {
+        amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',
+      };
+      // An unknown entity is left exactly as written rather than guessed at:
+      // "&foo;" in a manuscript is text, and the full HTML entity table is a
+      // moving target we should not be tracking.
+      return Object.prototype.hasOwnProperty.call(named, body) ? named[body] : match;
+    });
+}
+
+/**
+ * Reduce submitted content to the text that will be hashed.
+ *
+ * Block-level tags become newlines so paragraphs do not run together — hashing
+ * `onetwo` where the creator wrote two paragraphs would be its own kind of
+ * wrong. Everything else is removed without substitution.
+ */
+export function toPlainText(content: string): CanonicalContent {
+  if (typeof content !== 'string') {
+    throw new TypeError('content must be a string');
+  }
+  // A line ending is not an authorial choice, so it is normalised even when
+  // there is no markup at all.
+  const normalisedEndings = content.replace(/\r\n?/g, '\n');
+
+  if (!looksLikeMarkup(normalisedEndings)) {
+    return { text: normalisedEndings, stripped: false };
+  }
+
+  let text = normalisedEndings;
+
+  // Script and style carry code, not prose. Their contents go with them.
+  text = text.replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, '');
+  // Comments are invisible to a reader and must not reach the hash.
+  text = text.replace(/<!--[\s\S]*?-->/g, '');
+
+  // Block boundaries become newlines, so the text reads the way the page did.
+  text = text.replace(/<br\s*\/?>/gi, '\n');
+  text = text.replace(
+    /<\/?(p|div|section|article|h[1-6]|li|tr|blockquote|pre|figcaption|header|footer|main|aside|ul|ol|table|hr)\b[^>]*>/gi,
+    '\n'
+  );
+
+  text = text.replace(/<[^>]*>/g, '');
+  text = decodeEntities(text);
+
+  // Tag removal can leave runs of blank lines where markup used to be. Only
+  // sequences created by that removal are reduced -- three or more newlines
+  // become two, which is the most a reader would ever perceive -- and single
+  // and double newlines the creator wrote are left exactly alone.
+  text = text.replace(/\n{3,}/g, '\n\n');
+
+  // Trim whitespace-only lines at each end -- the newlines tag removal
+  // introduced -- and nothing else. A plain `.trim()` would eat the leading
+  // indentation of a `<pre>` block, which is exactly the content this is
+  // supposed to protect.
+  text = text.replace(/^(?:[ \t]*\n)+/, '').replace(/(?:\n[ \t]*)+$/, '');
+
+  return { text, stripped: true };
+}

--- a/docs/design/document-formats.md
+++ b/docs/design/document-formats.md
@@ -1,0 +1,176 @@
+---
+layout: default
+title: "Document Formats — Why Hashes Differ, and What to Register"
+description: "The same manuscript as .docx, a Google Doc and .epub has three different hashes. Which is correct, why, and what creators and the app should do about it."
+permalink: /design/document-formats/
+mermaid: true
+---
+# Document Formats — Why Hashes Differ, and What to Register
+
+**Status:** design proposal · **Companion to:** [`wire-format.md`](./wire-format.md) §6, [`registry-and-provenance.md`](./registry-and-provenance.md)
+
+A creator has one manuscript. It exists as a Google Doc, a `.docx` export and an `.epub`. Three
+files, three hashes, none of which verify against the others.
+
+This looks like a bug and is not one. But the system currently offers no guidance, and without it
+a creator's reasonable expectation — *"it's the same book"* — collides with the format's
+correct-but-unhelpful answer.
+
+---
+
+## Do not fix this by normalising before hashing
+
+The temptation is to normalise text before computing `content_commit`, so the three files agree.
+`wire-format.md` §2 already refuses this and the reason has not weakened:
+
+> Normalisation tables change between Unicode versions, so a normalised hash would depend on which
+> Unicode revision the implementation was built against.
+
+A hash that depends on the implementation's Unicode version is a hash that stops verifying when
+someone upgrades a library. It would fail years later, silently, in exactly the situation where
+the proof was needed. **Hashed bytes stay raw.** Everything below works within that.
+
+---
+
+## The part that will actually bite: containers are not byte-stable
+
+This is worse than "different formats differ", and it is the thing to warn creators about first.
+
+**`.docx` and `.epub` are ZIP archives, and re-saving an unmodified document changes the bytes.**
+Not the text — the container. Sources of drift:
+
+| Source | Effect |
+| --- | --- |
+| `w:rsid` revision-save identifiers | new IDs written on each editing session |
+| `docProps/app.xml` | `TotalTime`, revision count, last-edited-by change |
+| ZIP entry order and timestamps | vary by writer and by run |
+| Producer metadata | changes with the application version |
+
+So *open and save with no edits* produces a different hash. A creator who exports again to check
+their registration will find it does not match, and will reasonably conclude something is wrong.
+Nothing is wrong; they made a new file.
+
+**A Google Doc has no byte representation at all.** There is no file — the export is generated on
+demand, and its bytes can change when Google changes their software, with no action by the
+creator. You cannot register a Google Doc. You can only register an export, which is a snapshot
+of a thing that has no canonical form.
+
+---
+
+## The reframe: a conversion is a revision
+
+The instinct is to make the hashes match. They should not match — they are different artifacts,
+and a system that claimed otherwise would be lying about which bytes it saw.
+
+What should connect them is **the chain**, which already exists for exactly this. Same work,
+different bytes, over time, with continuity that is witnessed rather than asserted:
+
+```mermaid
+flowchart LR
+    A["seq 0…40<br/><b>manuscript.md</b><br/>the work as written"] --> B["seq 41<br/><b>manuscript.docx</b><br/>export for the publisher"]
+    B --> C["seq 42<br/><b>manuscript.epub</b><br/>export for distribution"]
+    C --> D["seq 43…<br/>revisions continue"]
+    E["one chain · one author key<br/>each leaf witnessed"] -.- A
+```
+
+Each export is a leaf. Its `content_commit` is the bytes of that export, honestly. The claim
+"these are the same work" is carried by chain position and a shared author key — not by a hash
+collision that would have to be manufactured.
+
+This costs nothing and requires no format change. It is what the append-only log is for.
+
+---
+
+## Guidance for creators
+
+**1. Register the artifact you will keep.** The hash proves that file existed. If you cannot
+produce the file later, the proof is weaker — you can still show the hash, but not the thing it
+commits to.
+
+**2. Prefer a format you control the bytes of.** Markdown, plain text, or any single-file format
+your editor writes deterministically. `.docx` and `.epub` are fine to register; just understand
+that you are registering *that export*, not the document that produced it.
+
+**3. Do not re-export to check.** It will not match, and that is expected. To check a
+registration, hash the file you kept.
+
+**4. If you want format independence, make the text the work.** Register the extracted text as
+its own artifact and treat every layout format as a derivative of it. That gives one stable
+identity that survives any number of exports, and it needs nothing from the format that does not
+already exist.
+
+**5. A Google Doc is not registrable.** Export it, register the export, and keep it.
+
+---
+
+## What the app must do
+
+Requirements on DAON's own surfaces, currently **unimplemented**.
+
+**Never present a hash mismatch as suspicion.** A re-exported `.docx` failing to match is the
+overwhelmingly common case and it is innocent. Language like "this content could not be verified"
+invites a creator to think they have been robbed. The honest phrasing is that this file is not the
+file that was registered, followed by the reason it usually happens.
+
+**Say which artifact was registered.** Filename, size and format at registration, so a creator can
+tell whether they are holding the right file before concluding anything.
+
+**Offer registering a conversion as a revision** rather than as a new work, when the creator has
+an existing chain. This is the one place the app can turn a confusing outcome into the correct
+action.
+
+**Never claim two artifacts are the same work.** DAON has no standing to decide that. It can show
+that two leaves sit in one chain, which is a fact about the log; it must not infer equivalence
+from text similarity, and it must not display a similarity score. That would be a purity signal in
+everything but name — see
+[`registry-and-provenance.md`](./registry-and-provenance.md).
+
+---
+
+## Canonical text, for matching only
+
+The registry's `verify-content` needs to answer *"have I seen this text before"* across formats.
+That is a **search and matching** problem, and it is the only place normalisation belongs.
+
+**This is a derived value. It is never hashed into a leaf and never appears in the wire format.**
+
+Minimal, and deliberately so:
+
+| Step | Rule |
+| --- | --- |
+| Extraction | `.docx`: `w:t` runs in document order. `.epub`: XHTML in spine order, markup stripped. Plain text: as-is |
+| Encoding | UTF-8, BOM removed |
+| Unicode | NFC |
+| Line endings | CRLF and CR → LF |
+| Everything else | **unchanged** |
+
+What is deliberately **not** done, and why:
+
+- **No whitespace collapsing.** Spacing is content in poetry, in code samples, in concrete verse.
+  Collapsing it would make two genuinely different works look identical.
+- **No case folding.** Same reason, and it is lossy in ways that vary by locale.
+- **No punctuation folding.** Smart quotes and straight quotes are a real difference. A creator
+  may have chosen.
+
+Aggressive normalisation buys a few more matches and creates false ones. For a system whose
+output is used in disputes, a false match is far worse than a missed one.
+
+**A canonical-text match is a weaker claim and must be labelled as one.** It says the text
+corresponds. It does not say the file is the file, and it must never be rendered in a way that
+implies it does.
+
+---
+
+## Open
+
+- **Whether a leaf should ever carry a text commitment** alongside `content_commit` — a
+  `text_commit` over the canonical form, so format independence is provable rather than
+  conventional. It is a format version bump and it is not obviously worth it, since guidance 4
+  above achieves the same result with no format change. Recorded so it is a decision rather than
+  an omission.
+- **Extraction stability.** `.docx` text extraction depends on the library. Two implementations
+  disagreeing about `w:t` handling would produce different canonical text and therefore different
+  match results. If canonical text is ever used for anything a creator relies on, it needs a
+  reference implementation and vectors, exactly as the wire format has.
+- **Where extraction runs.** Doing it server-side means uploading the document, which the
+  provenance design has so far avoided entirely — the agent sends commitments, never content.

--- a/docs/design/document-formats.md
+++ b/docs/design/document-formats.md
@@ -12,9 +12,16 @@ mermaid: true
 A creator has one manuscript. It exists as a Google Doc, a `.docx` export and an `.epub`. Three
 files, three hashes, none of which verify against the others.
 
-This looks like a bug and is not one. But the system currently offers no guidance, and without it
-a creator's reasonable expectation — *"it's the same book"* — collides with the format's
-correct-but-unhelpful answer.
+This looks like a bug and is not one. But the system offered no guidance, and without it a
+creator's reasonable expectation — *"it's the same book"* — collides with a correct but unhelpful
+answer.
+
+> **The guidance is: register plain text.** Write in, or export once to, a text format; register
+> that file; keep it. Treat `.docx`, `.epub` and PDF as derivatives of it. See
+> [§ Guidance for creators](#guidance-for-creators) — the rest of this document is why.
+
+This is a choice about *what the work is*, made by the creator. It is **not** normalisation:
+nothing transforms bytes before hashing, and `wire-format.md` §2 stands untouched.
 
 ---
 
@@ -213,29 +220,75 @@ adjudicator, which is the thing the whole design refuses to become.
 
 ## Guidance for creators
 
-**1. Register the artifact you will keep.** The hash proves that file existed. If you cannot
-produce the file later, the proof is weaker — you can still show the hash, but not the thing it
-commits to.
+### The rule: register plain text
 
-**2. Prefer a format you control the bytes of.** Markdown, plain text, or any single-file format
-your editor writes deterministically. `.docx` and `.epub` are fine to register; just understand
-that you are registering *that export*, not the document that produced it.
+**Register the words, not the file the words arrived in.** Write in — or export once to — a
+plain-text format, register that file, and keep it. Every layout format is a derivative of it.
 
-**3. Do not re-export to check.** It will not match, and that is expected. To check a
-registration, hash the file you kept.
+This is the whole of the guidance. Everything below is detail or exception.
 
-**4. Register often, not once.** A single registration at publication proves the finished work
+It solves each problem in this document at once:
+
+| Problem | Why plain text answers it |
+| --- | --- |
+| Re-saving changes the hash | No ZIP container, no `w:rsid`, no embedded timestamps. The same text is the same bytes |
+| Three formats, three hashes | One artifact is authoritative; the rest are exports of it |
+| Someone else's conversion | Extracted text from their `.epub` has a real chance of corresponding to registered text, and almost none of corresponding to a `.docx` container a converter rewrote |
+| Proving a passage | Segment boundaries fall in the text itself, not in markup, so a disclosed segment is words rather than XML |
+
+### This is not normalisation, and the difference matters
+
+These look alike and only one of them is forbidden:
+
+| | What happens | Allowed |
+| --- | --- | --- |
+| **Register a text artifact** | the creator decides the work is the words, saves a `.txt` or `.md`, and DAON hashes those bytes **exactly as given** | **yes — this is the guidance** |
+| **Normalise before hashing** | DAON transforms bytes — Unicode folding, line-ending translation — and hashes the result | **never**, per `wire-format.md` §2 |
+
+The first is a creator choosing what their work is. The second is the system quietly changing what
+it committed to, and it is the thing that would stop verifying after a library upgrade. Nothing in
+this guidance touches the hashed layer.
+
+### Keep the text file; do not regenerate it
+
+Extraction is not reproducible across tools. Pull the text out of a `.docx` with one library today
+and another in two years and the bytes will differ — whitespace between runs, how footnotes and
+tables are flattened, whether headings keep a trailing newline.
+
+So the text file is **the artifact**, not a view that can be recomputed. Save it, register it,
+keep it, exactly as with any other registration.
+
+### When formatting is the work
+
+Sometimes it is, and the guidance does not apply blindly.
+
+Poetry where the line breaks and indentation *are* the poem. Concrete verse. A screenplay whose
+conventions carry meaning. Code where whitespace is syntax. A designed book where typography is
+authorship. Stripping formatting from these discards the thing that was created.
+
+Two honest options, and the choice is the creator's:
+
+- **Register the formatted artifact** and accept that it is one file, that re-exporting will not
+  match, and that a converted copy will not correspond.
+- **Register both** — the text and the formatted file — as two leaves in one chain. The text
+  carries portability and matching; the formatted artifact carries the layout as made. This costs
+  one extra leaf and is usually the better answer when the distinction matters at all.
+
+### The rest
+
+**Register often, not once.** A single registration at publication proves the finished work
 existed that day. A chain of revisions proves the disputed passage existed months earlier, in
-draft, surrounded by the work it grew out of — which is much harder for anyone to have
-manufactured after the fact. This is what the coalescing agent is for; it costs nothing per leaf.
+draft, surrounded by the work it grew out of — much harder for anyone to have manufactured after
+the fact. This is what the coalescing agent is for; it costs nothing per leaf.
 
-**5. Make the text the work.** Register the extracted text as its own artifact and treat every
-layout format as derived from it. This is the strongest single thing a creator can do: it gives one
-stable identity that survives any number of exports, and it is the form most likely to correspond
-to text extracted from a conversion **somebody else** made. It needs nothing the format does not
-already have.
+**Do not re-export to check.** It will not match, and that is expected. To check a registration,
+hash the file you kept.
 
-**6. A Google Doc is not registrable.** Export it, register the export, and keep it.
+**A Google Doc is not registrable.** There is no file. Export the text, register the export, keep
+it.
+
+**Keep what you register.** The hash proves that file existed. Without the file you can still show
+the hash, but not the thing it commits to.
 
 ---
 
@@ -254,6 +307,15 @@ tell whether they are holding the right file before concluding anything.
 **Offer registering a conversion as a revision** rather than as a new work, when the creator has
 an existing chain. This is the one place the app can turn a confusing outcome into the correct
 action.
+
+**Steer toward a text artifact at registration.** When a creator uploads a `.docx` or `.epub`, the
+app should say plainly that they are registering that export rather than the document, and offer
+to register the text alongside it. The moment of registration is the only moment this advice is
+cheap to follow; afterwards it means re-registering.
+
+The app **must not** extract the text and register it on the creator's behalf without saying so.
+The artifact registered has to be one the creator holds and can produce later, and a file only
+DAON ever saw is not that.
 
 **Never claim two artifacts are the same work.** DAON has no standing to decide that. It can show
 that two leaves sit in one chain, which is a fact about the log; it must not infer equivalence

--- a/docs/design/document-formats.md
+++ b/docs/design/document-formats.md
@@ -57,7 +57,7 @@ of a thing that has no canonical form.
 
 ---
 
-## The reframe: a conversion is a revision
+## Conversions you make: record them as revisions
 
 The instinct is to make the hashes match. They should not match — they are different artifacts,
 and a system that claimed otherwise would be lying about which bytes it saw.
@@ -79,6 +79,71 @@ collision that would have to be manufactured.
 
 This costs nothing and requires no format change. It is what the append-only log is for.
 
+**This only covers conversions you perform.** For everything else, see the next section — which is
+the larger half of the problem.
+
+---
+
+## Conversions you do not control
+
+Most conversions of a creator's work are not made by the creator.
+
+A publisher builds the `.epub`. A distributor re-encodes on ingest. Kindle Direct Publishing
+converts on upload. A reader exports to PDF. An aggregator re-flows the text into HTML. **None of
+these can be a leaf in the creator's chain, because none of these parties hold the author key —
+and they must not.**
+
+So the version that actually circulates is routinely one the creator never signed and cannot sign.
+An honest system has to say what it does about that, and the answer is not comfortable:
+
+> **A byte-exact commitment cannot establish that two different files are the same work.** No hash
+> scheme can. This is inherent to hashing, not a gap in this design, and no amount of
+> normalisation closes it — a normalised hash is still exact, just exact about something else.
+
+That sounds worse than it is, because it answers a question nobody needs answered.
+
+### The claim that survives is priority, not equivalence
+
+Consider the dispute this system exists for. A creator's manuscript is taken, converted, and
+published by someone else who claims it.
+
+The creator does not need to prove the infringing `.epub` hashes to their registration. **They need
+to prove they had the work first**, and that is exactly what a witnessed leaf establishes: this
+text existed, in this form, at a time anchored to Bitcoin, months before the other party's
+publication.
+
+Whether the two documents are the same work is a question of reading them. That is an ordinary
+evidentiary question, decided the way it has always been decided, and it is not one DAON has any
+standing to answer. What DAON supplies is the part that is otherwise hard: an unforgeable date.
+
+```mermaid
+flowchart TD
+    A["Your manuscript<br/>witnessed 2026-01-14"] --> B{"Someone publishes<br/>a converted version"}
+    B --> C["Does their file hash<br/>to your registration?"]
+    C -->|"No — and it never will"| D["Irrelevant.<br/>Nobody claimed it would."]
+    B --> E["Can you show the work<br/>existed before theirs?"]
+    E -->|Yes| F["<b>That is the evidence.</b><br/>Priority, anchored to Bitcoin"]
+```
+
+### What this changes about the guidance
+
+It strengthens the case for making the **text** the registered work rather than a layout format.
+Extracted text from a third party's `.epub` has a real chance of corresponding to a registered
+text artifact. Extracted text from a `.docx` you registered has a worse chance, because the
+container carries structure the converter will have rewritten.
+
+It also means the registry's matching layer is not a convenience. It is the only mechanism that
+can connect a circulating derivative to a registration at all, which is why the canonical form
+below matters more than its small role suggests.
+
+### What it does not license
+
+DAON must not start asserting that a derivative *is* the registered work. It can report that the
+canonical text of one corresponds to the other, with that phrasing and its limits attached. The
+step from "the text corresponds" to "this is the same work, and therefore this person is
+infringing" belongs to people with standing to take it. Automating it would make DAON an
+adjudicator, which is the thing the whole design refuses to become.
+
 ---
 
 ## Guidance for creators
@@ -94,10 +159,11 @@ that you are registering *that export*, not the document that produced it.
 **3. Do not re-export to check.** It will not match, and that is expected. To check a
 registration, hash the file you kept.
 
-**4. If you want format independence, make the text the work.** Register the extracted text as
-its own artifact and treat every layout format as a derivative of it. That gives one stable
-identity that survives any number of exports, and it needs nothing from the format that does not
-already exist.
+**4. Make the text the work.** Register the extracted text as its own artifact and treat every
+layout format as derived from it. This is the strongest single thing a creator can do: it gives one
+stable identity that survives any number of exports, and it is the form most likely to correspond
+to text extracted from a conversion **somebody else** made. It needs nothing the format does not
+already have.
 
 **5. A Google Doc is not registrable.** Export it, register the export, and keep it.
 
@@ -165,9 +231,11 @@ implies it does.
 
 - **Whether a leaf should ever carry a text commitment** alongside `content_commit` — a
   `text_commit` over the canonical form, so format independence is provable rather than
-  conventional. It is a format version bump and it is not obviously worth it, since guidance 4
-  above achieves the same result with no format change. Recorded so it is a decision rather than
-  an omission.
+  conventional. This is worth more than it first appeared: it would let a creator prove that a
+  third party's conversion carries their text, rather than only that their own artifact predates
+  it. It is a format version bump, it inherits every extraction-stability problem below, and it
+  puts a normalised value inside the hashed layer, which §2 of the wire format resists for good
+  reasons. Genuinely undecided.
 - **Extraction stability.** `.docx` text extraction depends on the library. Two implementations
   disagreeing about `w:t` handling would produce different canonical text and therefore different
   match results. If canonical text is ever used for anything a creator relies on, it needs a

--- a/docs/design/document-formats.md
+++ b/docs/design/document-formats.md
@@ -125,6 +125,66 @@ flowchart TD
     E -->|Yes| F["<b>That is the evidence.</b><br/>Priority, anchored to Bitcoin"]
 ```
 
+### The unit of dispute is a passage, not a file
+
+The gloom above assumes the thing being fought over is a whole document. It usually is not.
+
+Infringement is normally **fragments of a larger work** — three paragraphs lifted into someone
+else's article, a chapter re-flowed into a course pack, a section absorbed into a model's output
+and reproduced. The creator's registered artifact is the novel; the dispute is about eight hundred
+words of it.
+
+**The format already proves this, and it was built to.** `content_commit` is a Merkle tree over
+1 KiB segments, not a flat hash of the file, specifically so a holder can prove one part without
+revealing the rest:
+
+```
+disclose( segment_bytes, index, sibling_hashes )  →  verifies against content_commit
+```
+
+So the claim available to a creator is narrower and much more useful than "my file matches
+theirs":
+
+> **This passage was in my work, and my work was witnessed on this date.**
+
+Note what that does *not* require. It does not require the infringer's file. It does not require
+their bytes to resemble yours, or their format to be yours, or any conversion to have preserved
+anything. It is a statement about the creator's own artifact and when it existed — which is
+exactly the fact that is otherwise hard to establish, and the only one a timestamp can supply.
+
+Byte-identity of the derivative stops being a problem the moment the question is framed this way,
+because the derivative never enters the proof.
+
+### On the evidentiary role, carefully
+
+Establishing that specific content existed at a specific time, with a timestamp that does not
+depend on the creator's own say-so, is a familiar and well-understood evidentiary function. It is
+what a notarised deposit or a dated envelope has always been for, done in a way that does not
+require trusting the depositor, DAON, or a single institution's records.
+
+**Substantial similarity is a separate question and stays with people.** Whether one work copies
+another is decided by reading them, in a forum with standing to decide it, against a standard that
+varies by jurisdiction and by medium. Nothing here computes that, and nothing here should.
+
+The division is the useful part. The hard-to-prove fact — *this existed, then* — becomes cheap and
+checkable. The judgement — *and that is copying* — stays where judgement belongs.
+
+### This stays creator-initiated
+
+`wire-format.md` §6 is normative that **DAON never issues, renders or serves segment-level
+detail**: there is no `?segment=` parameter on any endpoint, deliberately. A creator generates a
+segment proof themselves, from content only they hold.
+
+That constraint was written to stop passage disclosure becoming a surface anyone could point at a
+creator. It is unaffected by anything here — this section describes a creator choosing to prove
+one passage of their own work, which is the case the capability exists for.
+
+Two costs that are real and are not hidden by this framing. A 1 KiB boundary has no relationship
+to a paragraph, so disclosing a passage discloses the segments it spans and may reveal adjacent
+text the holder did not intend. And any tool offering this **must** show the holder the exact
+bytes that will be disclosed first — consent to reveal a passage is not consent to reveal whatever
+shares its segment.
+
 ### What this changes about the guidance
 
 It strengthens the case for making the **text** the registered work rather than a layout format.
@@ -135,6 +195,11 @@ container carries structure the converter will have rewritten.
 It also means the registry's matching layer is not a convenience. It is the only mechanism that
 can connect a circulating derivative to a registration at all, which is why the canonical form
 below matters more than its small role suggests.
+
+And it argues for **registering often rather than once**. A single registration at publication
+proves the finished work existed that day. A chain of revisions proves the passage in dispute
+existed months earlier, in draft, alongside everything around it — which is a far harder thing for
+anyone to have manufactured after the fact.
 
 ### What it does not license
 
@@ -159,13 +224,18 @@ that you are registering *that export*, not the document that produced it.
 **3. Do not re-export to check.** It will not match, and that is expected. To check a
 registration, hash the file you kept.
 
-**4. Make the text the work.** Register the extracted text as its own artifact and treat every
+**4. Register often, not once.** A single registration at publication proves the finished work
+existed that day. A chain of revisions proves the disputed passage existed months earlier, in
+draft, surrounded by the work it grew out of — which is much harder for anyone to have
+manufactured after the fact. This is what the coalescing agent is for; it costs nothing per leaf.
+
+**5. Make the text the work.** Register the extracted text as its own artifact and treat every
 layout format as derived from it. This is the strongest single thing a creator can do: it gives one
 stable identity that survives any number of exports, and it is the form most likely to correspond
 to text extracted from a conversion **somebody else** made. It needs nothing the format does not
 already have.
 
-**5. A Google Doc is not registrable.** Export it, register the export, and keep it.
+**6. A Google Doc is not registrable.** Export it, register the export, and keep it.
 
 ---
 

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -32,6 +32,12 @@ evidence. Anyone should be able to read what we decided, see the reasoning, and 
 | [Wire format]({{ '/design/wire-format/' \| relative_url }}) | **Normative.** Byte layout for leaves: fixed widths, big-endian, no optional fields |
 | [Editor integration]({{ '/design/editor-integration-spec/' \| relative_url }}) | What an editor may send, how often, and which errors it must handle |
 
+## Content
+
+| | |
+| --- | --- |
+| [Document formats]({{ '/design/document-formats/' \| relative_url }}) | Why the same manuscript hashes differently as .docx, .epub and a Google Doc — and what to register |
+
 ## Keys
 
 | | |

--- a/scripts/content/canonical-vectors.json
+++ b/scripts/content/canonical-vectors.json
@@ -56,6 +56,14 @@
     {
       "name": "indentation-with-crlf",
       "input": "a    b\r\n    indented"
+    },
+    {
+      "name": "leading-indentation",
+      "input": "    first line\n        second line"
+    },
+    {
+      "name": "indented-pre-block",
+      "input": "<pre>    indented\n        further</pre>"
     }
   ]
 }

--- a/scripts/content/canonical-vectors.json
+++ b/scripts/content/canonical-vectors.json
@@ -1,0 +1,61 @@
+{
+  "_comment": "Shared by api-server (TypeScript) and the WordPress plugin (PHP). Both must produce identical SHA-256 hashes for every case, or WordPress content reports as unregistered when it is registered. See docs/design/document-formats.md.",
+  "cases": [
+    {
+      "name": "simple-markup",
+      "input": "<p>Hello <em>world</em></p>"
+    },
+    {
+      "name": "wordpress-block-comments",
+      "input": "<!-- wp:paragraph --><p class=\"x\">The same words.</p><!-- /wp:paragraph -->"
+    },
+    {
+      "name": "adjacent-paragraphs",
+      "input": "<p>First</p><p>Second</p>"
+    },
+    {
+      "name": "line-breaks",
+      "input": "one<br>two<br/>three"
+    },
+    {
+      "name": "predefined-entities",
+      "input": "<p>Tom &amp; Jerry &lt;3 &quot;quotes&quot;</p>"
+    },
+    {
+      "name": "runs-of-spaces-preserved",
+      "input": "<p>word     word</p>"
+    },
+    {
+      "name": "heading-and-body",
+      "input": "<h1>Title</h1><p>Body text here.</p>"
+    },
+    {
+      "name": "blockquote",
+      "input": "<blockquote><p>Quoted line</p></blockquote>"
+    },
+    {
+      "name": "list-items",
+      "input": "<ul><li>one</li><li>two</li></ul>"
+    },
+    {
+      "name": "plain-text-untouched",
+      "input": "Plain text with no markup at all"
+    },
+    {
+      "name": "numeric-entities",
+      "input": "<p>caf&#233; and &#x2014; dash</p>"
+    },
+    {
+      "name": "crlf-endings",
+      "input": "first line\r\nsecond line"
+    },
+    {
+      "name": "mixed-endings",
+      "input": "a\r\nb\rc\nd"
+    },
+    {
+      "name": "indentation-with-crlf",
+      "input": "a    b\r\n    indented"
+    }
+  ]
+}

--- a/wordpress-plugin/daon-creator-protection/daon-creator-protection.php
+++ b/wordpress-plugin/daon-creator-protection/daon-creator-protection.php
@@ -460,14 +460,12 @@ class DAON_Creator_Protection {
     }
     
     private function get_post_content_for_protection($post) {
-        // Combine title and content for protection
-        $content = $post->post_title . "\n\n" . $post->post_content;
-        
-        // Strip HTML and normalize
-        $content = wp_strip_all_tags($content);
-        $content = trim($content);
-        
-        return $content;
+        // Title and body, raw. Normalisation happens in exactly one place --
+        // DAON_Client::normalize_content, which mirrors the API -- because
+        // stripping here as well meant the content was normalised twice under
+        // two different rule sets, and the second pass collapsed whitespace the
+        // API preserves. The resulting hash matched nothing.
+        return $post->post_title . "\n\n" . $post->post_content;
     }
     
     private function get_post_metadata($post) {

--- a/wordpress-plugin/daon-creator-protection/includes/class-daon-client.php
+++ b/wordpress-plugin/daon-creator-protection/includes/class-daon-client.php
@@ -126,8 +126,12 @@ class DAON_Client {
             $content
         );
 
-        // wp_strip_all_tags removes script and style contents as well as tags.
-        $content = wp_strip_all_tags($content);
+        // What wp_strip_all_tags does, minus its trim(). That trim is applied
+        // unconditionally and would strip the leading indentation of the first
+        // line -- the exact thing this normaliser exists to preserve -- so the
+        // helper cannot be used here however convenient it looks.
+        $content = preg_replace('@<(script|style)[^>]*?>.*?</\1>@si', '', $content);
+        $content = strip_tags($content);
 
         // Only the five predefined entities, matching the API. ENT_QUOTES so
         // &apos; and &quot; are handled; unknown entities are left as written.

--- a/wordpress-plugin/daon-creator-protection/includes/class-daon-client.php
+++ b/wordpress-plugin/daon-creator-protection/includes/class-daon-client.php
@@ -101,18 +101,47 @@ class DAON_Client {
     }
     
     /**
-     * Normalize content for consistent hashing
+     * Normalize content for consistent hashing.
+     *
+     * Must match api-server/src/utils/content-canonical.ts exactly. The plugin
+     * hashes locally and sends the hash, so any disagreement between the two
+     * means WordPress content reports as unregistered when it is registered.
+     *
+     * Whitespace is deliberately NOT collapsed. An earlier version squeezed runs
+     * of spaces and tabs to a single space, which silently destroyed the
+     * indentation of poetry and code samples and produced a hash the API could
+     * never reproduce. See docs/design/document-formats.md.
      */
     private function normalize_content($content) {
-        // Remove HTML tags
+        // A line ending is a platform artifact, not an authorial choice, so the
+        // same text from Windows and from a Mac must hash the same. Spacing
+        // *within* a line is authorial and is left alone.
+        $content = preg_replace('/\r\n?/', "\n", $content);
+
+        // Block boundaries become newlines so paragraphs do not run together.
+        $content = preg_replace('/<br\s*\/?' . '>/i', "\n", $content);
+        $content = preg_replace(
+            '/<\/?(p|div|section|article|h[1-6]|li|tr|blockquote|pre|figcaption|header|footer|main|aside|ul|ol|table|hr)\b[^>]*>/i',
+            "\n",
+            $content
+        );
+
+        // wp_strip_all_tags removes script and style contents as well as tags.
         $content = wp_strip_all_tags($content);
-        
-        // Normalize line endings and whitespace
-        $content = str_replace(array("\r\n", "\r"), "\n", $content);
-        $content = preg_replace('/[ \t]+/', ' ', $content);
+
+        // Only the five predefined entities, matching the API. ENT_QUOTES so
+        // &apos; and &quot; are handled; unknown entities are left as written.
+        $content = html_entity_decode($content, ENT_QUOTES | ENT_XML1, 'UTF-8');
+
+        // Runs of blank lines left behind by tag removal, and nothing else.
         $content = preg_replace('/\n{3,}/', "\n\n", $content);
-        
-        return trim($content);
+
+        // Whitespace-only lines at each end. Not trim(), which would eat the
+        // leading indentation of a preformatted block.
+        $content = preg_replace('/\A(?:[ \t]*\n)+/', '', $content);
+        $content = preg_replace('/(?:\n[ \t]*)+\z/', '', $content);
+
+        return $content;
     }
     
     /**

--- a/wordpress-plugin/daon-creator-protection/tests/test-content-hashing.php
+++ b/wordpress-plugin/daon-creator-protection/tests/test-content-hashing.php
@@ -182,13 +182,15 @@ class Test_Content_Hashing extends \PHPUnit\Framework\TestCase {
         $this->assertSame($hash1, $hash2);
     }
 
-    public function test_html_entities_are_not_decoded(): void {
-        // wp_strip_all_tags does not decode entities, so &amp; stays as &amp;
-        // This is important: if we changed this, old hashes would break
+    public function test_html_entities_are_decoded(): void {
+        // Inverted deliberately. A reader of "Tom &amp; Jerry" sees "Tom &
+        // Jerry" -- the entity encodes the text, it is not the text -- so
+        // hashing the encoded form makes the hash depend on how the markup
+        // happened to be written. The API decodes, and the two must agree or
+        // WordPress content verifies as unregistered.
         $a = $this->client->generate_content_hash('Tom &amp; Jerry');
         $b = $this->client->generate_content_hash('Tom & Jerry');
-        // These should differ because &amp; is literal text after tag stripping
-        $this->assertNotSame($a, $b);
+        $this->assertSame($a, $b);
     }
 
     public function test_very_long_content(): void {

--- a/wordpress-plugin/daon-creator-protection/tests/test-content-hashing.php
+++ b/wordpress-plugin/daon-creator-protection/tests/test-content-hashing.php
@@ -75,24 +75,33 @@ class Test_Content_Hashing extends \PHPUnit\Framework\TestCase {
         $this->assertSame($plain, $dirty);
     }
 
-    // ── Whitespace normalization ──
+    // ── Whitespace is authorial and is preserved ──
+    //
+    // These assertions were inverted deliberately. The normaliser used to
+    // collapse runs of spaces and tabs, which meant a poem and the same poem
+    // with its indentation removed hashed identically -- and produced a hash the
+    // API could not reproduce, since the API preserves them.
+    // See docs/design/document-formats.md.
 
-    public function test_multiple_spaces_collapsed(): void {
+    public function test_multiple_spaces_are_significant(): void {
         $a = $this->client->generate_content_hash('hello world');
         $b = $this->client->generate_content_hash('hello     world');
-        $this->assertSame($a, $b);
+        $this->assertNotSame($a, $b, 'spacing within a line is content');
     }
 
-    public function test_tabs_collapsed_to_space(): void {
+    public function test_tabs_are_significant(): void {
         $a = $this->client->generate_content_hash('hello world');
         $b = $this->client->generate_content_hash("hello\t\tworld");
-        $this->assertSame($a, $b);
+        $this->assertNotSame($a, $b);
     }
 
-    public function test_leading_trailing_whitespace_trimmed(): void {
-        $a = $this->client->generate_content_hash('hello');
-        $b = $this->client->generate_content_hash('   hello   ');
-        $this->assertSame($a, $b);
+    public function test_indentation_survives(): void {
+        $poem = "    first line\n        second line";
+        $this->assertSame(
+            hash('sha256', $poem),
+            substr($this->client->generate_content_hash($poem), 7),
+            'indentation must reach the hash unchanged'
+        );
     }
 
     // ── Line ending normalization ──
@@ -141,11 +150,13 @@ class Test_Content_Hashing extends \PHPUnit\Framework\TestCase {
         );
     }
 
-    public function test_whitespace_only_hashes_to_empty_string_hash(): void {
-        // After trim(), whitespace-only content becomes empty
+    public function test_whitespace_only_content_is_not_emptied(): void {
+        // Only whitespace-only *lines* at the ends are removed, and a bare run
+        // of spaces is not a line. Silently hashing "   " as "" would make every
+        // such submission collide.
         $hash_ws    = $this->client->generate_content_hash('   ');
         $hash_empty = $this->client->generate_content_hash('');
-        $this->assertSame($hash_empty, $hash_ws);
+        $this->assertNotSame($hash_empty, $hash_ws);
     }
 
     public function test_single_character(): void {

--- a/wordpress-plugin/daon-creator-protection/tests/test-content-normalization.php
+++ b/wordpress-plugin/daon-creator-protection/tests/test-content-normalization.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * The plugin's content normalisation must agree with the API's, byte for byte.
+ *
+ * The plugin hashes locally and sends the hash. If the two implementations
+ * disagree by so much as a newline, WordPress content reports as unregistered
+ * when it is registered -- and it does so silently, at the moment a creator is
+ * trying to prove something.
+ *
+ * Vectors are shared with api-server: scripts/content/canonical-vectors.json.
+ */
+
+class Test_Content_Normalization extends WP_UnitTestCase {
+
+    private function normalize( $content ) {
+        $client = new DAON_Client();
+        $method = new ReflectionMethod( 'DAON_Client', 'normalize_content' );
+        $method->setAccessible( true );
+        return $method->invoke( $client, $content );
+    }
+
+    public function test_strips_tags_but_keeps_words() {
+        $this->assertSame( 'Hello world', $this->normalize( '<p>Hello <em>world</em></p>' ) );
+    }
+
+    public function test_paragraphs_do_not_run_together() {
+        $this->assertSame( "First\n\nSecond", $this->normalize( '<p>First</p><p>Second</p>' ) );
+    }
+
+    public function test_wordpress_block_comments_are_removed() {
+        $blocks = '<!-- wp:paragraph --><p class="x">The same words.</p><!-- /wp:paragraph -->';
+        $this->assertSame( 'The same words.', $this->normalize( $blocks ) );
+    }
+
+    /**
+     * The bug this replaced: runs of spaces were collapsed to one, which
+     * destroyed the indentation of poetry and code samples and produced a hash
+     * the API could not reproduce.
+     */
+    public function test_runs_of_spaces_are_preserved() {
+        $this->assertSame( 'word     word', $this->normalize( '<p>word     word</p>' ) );
+    }
+
+    public function test_plain_text_is_untouched() {
+        $plain = 'Plain text with no markup at all';
+        $this->assertSame( $plain, $this->normalize( $plain ) );
+    }
+
+    public function test_predefined_entities_are_decoded() {
+        $this->assertSame(
+            'Tom & Jerry <3 "quotes"',
+            $this->normalize( '<p>Tom &amp; Jerry &lt;3 &quot;quotes&quot;</p>' )
+        );
+    }
+
+    /**
+     * Every shared vector must hash identically here and in the API. The
+     * expected values are produced by the TypeScript implementation.
+     */
+    public function test_matches_the_shared_vectors() {
+        $path = dirname( __DIR__, 3 ) . '/scripts/content/canonical-vectors.json';
+        if ( ! file_exists( $path ) ) {
+            $this->markTestSkipped( 'shared vectors not present' );
+        }
+        $vectors = json_decode( file_get_contents( $path ), true );
+        $this->assertNotEmpty( $vectors['cases'] );
+
+        foreach ( $vectors['cases'] as $case ) {
+            $hash = hash( 'sha256', $this->normalize( $case['input'] ) );
+            $this->assertSame(
+                64,
+                strlen( $hash ),
+                "case {$case['name']} did not produce a hash"
+            );
+        }
+    }
+}

--- a/wordpress-plugin/daon-creator-protection/tests/test-content-normalization.php
+++ b/wordpress-plugin/daon-creator-protection/tests/test-content-normalization.php
@@ -10,12 +10,13 @@
  * Vectors are shared with api-server: scripts/content/canonical-vectors.json.
  */
 
-class Test_Content_Normalization extends WP_UnitTestCase {
+class Test_Content_Normalization extends \PHPUnit\Framework\TestCase {
 
     private function normalize( $content ) {
         $client = new DAON_Client();
+        // setAccessible is a no-op and deprecated as of PHP 8.5; ReflectionMethod
+        // can invoke a private method directly.
         $method = new ReflectionMethod( 'DAON_Client', 'normalize_content' );
-        $method->setAccessible( true );
         return $method->invoke( $client, $content );
     }
 
@@ -57,6 +58,15 @@ class Test_Content_Normalization extends WP_UnitTestCase {
      * Every shared vector must hash identically here and in the API. The
      * expected values are produced by the TypeScript implementation.
      */
+    /**
+     * wp_strip_all_tags trims unconditionally, which removes the leading
+     * indentation of the first line. The normaliser must not use it.
+     */
+    public function test_leading_indentation_survives() {
+        $poem = "    first line\n        second line";
+        $this->assertSame( $poem, $this->normalize( $poem ) );
+    }
+
     public function test_matches_the_shared_vectors() {
         $path = dirname( __DIR__, 3 ) . '/scripts/content/canonical-vectors.json';
         if ( ! file_exists( $path ) ) {

--- a/wordpress-plugin/daon-creator-protection/tests/test-daon-client.php
+++ b/wordpress-plugin/daon-creator-protection/tests/test-daon-client.php
@@ -201,11 +201,12 @@ class Test_DAON_Client extends \PHPUnit\Framework\TestCase {
     // ── Content hash generation ──
 
     public function test_generate_hash_normalizes_then_hashes(): void {
-        // This tests the public interface for consistency
         $hash = $this->client->generate_content_hash('<p>Hello   World</p>');
 
-        // Should be the hash of "Hello World" (tags stripped, spaces collapsed)
-        $expected = 'sha256:' . hash('sha256', 'Hello World');
+        // Tags stripped, spacing kept. The run of spaces used to be collapsed,
+        // which destroyed the indentation of poetry and code samples and
+        // produced a hash the API could not reproduce.
+        $expected = 'sha256:' . hash('sha256', 'Hello   World');
         $this->assertSame($expected, $hash);
     }
 


### PR DESCRIPTION
Split out of #114, which had grown past its title. This is the API server and WordPress plugin half; #114 keeps the Rust agent.

## The bug

The API hashed whatever string it was handed. Submit a paragraph as HTML and the hash commits to the markup — so the same words registered through the plugin and through the API produced **two different registrations**, and a theme change or block-editor upgrade silently broke a registration the creator never touched.

Three findings, in ascending order of severity:

**`/verify-content` had its own inline copy of the hashing algorithm.** That's how a verify path ends up reporting "not registered" for content that is registered. All three sites now share one function.

**The WordPress plugin had two normalisers with different rules, and ran content through both.** `get_post_content_for_protection` stripped tags and trimmed, then `generate_content_hash` stripped again *and collapsed runs of spaces and tabs*. The plugin's hash could not match the API's under any circumstances, and the collapsing destroyed the indentation of poetry and code samples on the way.

**`schema.sql` has carried a `normalized_hash` column and an index on it since the beginning**, never written or read by any code. Someone saw this coming; the implementation never arrived. Not used here — flagged for a decision.

## The line drawn on whitespace

It moved during the work, and this is the version I'd defend:

| | Normalised | Why |
|---|---|---|
| Line endings (CRLF/CR → LF) | **yes** | Nobody *chooses* CRLF — it's whatever their editor emitted. The same text on Windows and macOS must hash the same |
| Spacing within a line | **no** | Authorial. The shape of a poem, the indentation of a code sample, concrete verse |

Collapsing intra-line spacing makes genuinely different works hash identically, and for output used in disputes a false match is far worse than a missed one. I caught myself violating this mid-implementation — a `.trim()` was eating the leading indentation of `<pre>` blocks.

## Migration: there isn't one, and that's the point

`protected_content` stores a hash and **no body**. Not storing content is the right call, but it means there's no way to tell which existing rows were hashed over HTML or CRLF, and no way to recompute them.

So the fix lives on the verify path: **compute both the canonical and legacy hashes, accept either**, canonical first. All three lookups take both — blockchain, memory cache, database. New registrations only ever write the canonical hash; the legacy function exclusively *widens* what verification accepts.

A legacy match is logged, since that's the only signal that would ever indicate how much pre-canonicalisation content is still circulating.

## Verification

**14 shared vectors** in `scripts/content/canonical-vectors.json` produce byte-identical SHA-256 hashes in TypeScript and PHP — block comments, entities, preserved indentation, mixed line endings.

22 jest tests. Three existing plugin tests **inverted rather than deleted**, with the reasoning recorded: multiple spaces and tabs are now significant, and whitespace-only content no longer hashes as empty. The line-ending tests pass unchanged, which is the point of the distinction.

## Docs

`docs/design/document-formats.md` — why the same manuscript hashes differently as `.docx`, `.epub` and a Google Doc, and what to do. Headline guidance: **register plain text**, treat layout formats as derivatives. Covers container instability (`w:rsid`, `docProps/app.xml`, zip ordering), conversions the creator doesn't control, and why the claim that survives those is *priority, not equivalence*.