### PR TITLE
fix(content): refuse content that strips to nothing instead of hashing it

### DIFF
--- a/api-server/src/server.ts
+++ b/api-server/src/server.ts
@@ -8,7 +8,11 @@
  */
 
 import express from 'express';
-import { toPlainText } from './utils/content-canonical.js';
+import {
+  toPlainText,
+  EmptyAfterStrippingError,
+  EMPTY_SHA256,
+} from './utils/content-canonical.js';
 import cors from 'cors';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
@@ -225,7 +229,35 @@ const handleValidationErrors = (req, res, next) => {
  */
 function generateContentHash(content) {
   const { text } = toPlainText(content);
-  return crypto.createHash('sha256').update(text, 'utf8').digest('hex');
+  const hash = crypto.createHash('sha256').update(text, 'utf8').digest('hex');
+
+  // Backstop. toPlainText already refuses content that strips to nothing, but
+  // this is the value every such input collapses to, so it is checked at the
+  // point of hashing as well -- a future path that skips canonicalisation must
+  // not be able to register the hash of no content.
+  if (hash === EMPTY_SHA256) {
+    throw new EmptyAfterStrippingError();
+  }
+  return hash;
+}
+
+/**
+ * Turn an EmptyAfterStrippingError into a 400 that says what to do.
+ *
+ * Content that vanishes under text extraction -- an image-only page, a scan, a
+ * figure without a caption -- is a client mistake about which pipeline to use,
+ * not a server fault.
+ */
+function handleEmptyContent(e, res) {
+  if (e instanceof EmptyAfterStrippingError) {
+    res.status(400).json({
+      success: false,
+      error: 'no_text_content',
+      message: e.message,
+    });
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -545,6 +577,7 @@ app.post("/api/v1/protect", [optionalAuth,
     });
     
   } catch (error) {
+    if (handleEmptyContent(error, res)) return;
     contentProtectionsTotal.labels(req.body.license || 'liberation_v1', 'error').inc();
     logger.error('Content protection failed:', error);
     res.status(500).json({
@@ -623,6 +656,7 @@ app.post('/api/v1/protect/bulk', [
     });
     
   } catch (error) {
+    if (handleEmptyContent(error, res)) return;
     logger.error('Bulk protection failed:', error);
     res.status(500).json({
       success: false,
@@ -876,6 +910,7 @@ app.post('/api/v1/verify-content', [
     });
 
   } catch (error) {
+    if (handleEmptyContent(error, res)) return;
     logger.error('Verify-content failed:', error);
     res.status(500).json({
       success: false,
@@ -1034,6 +1069,7 @@ app.post('/api/v1/broker/protect',
     });
     
   } catch (error) {
+    if (handleEmptyContent(error, res)) return;
     logger.error('Broker protection failed:', error);
     contentProtectionsTotal.labels('unknown', 'error').inc();
     

--- a/api-server/src/test/content-canonical.test.ts
+++ b/api-server/src/test/content-canonical.test.ts
@@ -4,7 +4,11 @@
  * The contract these protect: the words are hashed, the markup is not, and
  * whitespace the creator wrote survives untouched.
  */
-import { toPlainText } from '../utils/content-canonical.js';
+import {
+  toPlainText,
+  EmptyAfterStrippingError,
+  EMPTY_SHA256,
+} from '../utils/content-canonical.js';
 
 describe('toPlainText', () => {
   describe('leaves plain text alone', () => {
@@ -150,5 +154,69 @@ describe('line endings', () => {
 
   it('still leaves intra-line spacing alone', () => {
     expect(toPlainText('a    b\r\n    indented').text).toBe('a    b\n    indented');
+  });
+});
+
+describe('content that vanishes under stripping', () => {
+  // The bug this closes: an image-only document strips to "" and hashes to
+  // e3b0c442… — the SHA-256 of nothing. Every such work collided, the first
+  // registration made the rest return "already protected", and the one that
+  // succeeded committed to an empty document.
+  it('refuses image-only content instead of hashing nothing', () => {
+    expect(() => toPlainText('<img src="cliffs.jpg" alt="">')).toThrow(
+      EmptyAfterStrippingError
+    );
+  });
+
+  it('refuses a scanned page', () => {
+    expect(() => toPlainText('<figure><img src="page001.tiff"></figure>')).toThrow(
+      EmptyAfterStrippingError
+    );
+  });
+
+  it('refuses markup carrying no text at all', () => {
+    expect(() => toPlainText('<div><span></span><br><hr></div>')).toThrow(
+      EmptyAfterStrippingError
+    );
+  });
+
+  it('refuses a document whose only content is a script', () => {
+    expect(() => toPlainText('<script>const a = 1;</script>')).toThrow(
+      EmptyAfterStrippingError
+    );
+  });
+
+  // Distinctness is the point: three different works must not share a hash.
+  it('would otherwise have collided them', () => {
+    const works = [
+      '<img src="cliffs.jpg">',
+      '<img src="portrait-of-my-mother.jpg">',
+      '<figure><img src="page001.tiff"></figure>',
+    ];
+    for (const w of works) {
+      expect(() => toPlainText(w)).toThrow(EmptyAfterStrippingError);
+    }
+  });
+
+  it('still accepts an illustrated page that has a caption', () => {
+    const { text } = toPlainText('<img src="plate1.png"><p>Plate I</p>');
+    expect(text).toBe('Plate I');
+  });
+
+  // Plain text is never routed through stripping, so whitespace-only input is
+  // returned unchanged rather than refused. It hashes distinctly from empty.
+  it('leaves whitespace-only plain text alone', () => {
+    const { text, stripped } = toPlainText('   ');
+    expect(stripped).toBe(false);
+    expect(text).toBe('   ');
+  });
+});
+
+describe('the empty hash is never registrable', () => {
+  // Belt and braces: toPlainText refuses these inputs, and the hash they would
+  // have produced is refused independently at the point of hashing.
+  it('names the value so it can be checked at the hash site', () => {
+    const { createHash } = require('node:crypto');
+    expect(createHash('sha256').update('', 'utf8').digest('hex')).toBe(EMPTY_SHA256);
   });
 });

--- a/api-server/src/utils/content-canonical.ts
+++ b/api-server/src/utils/content-canonical.ts
@@ -34,6 +34,42 @@
  * those registrations were made against the raw bytes.
  */
 
+/**
+ * Thrown when stripping leaves nothing to hash.
+ *
+ * Not an edge case to tolerate: an image-only document, a scanned page, a
+ * figure with no caption all reduce to the empty string, and hashing that
+ * gives every one of them `e3b0c442…` — the SHA-256 of nothing. They would
+ * collide with each other, the first registration would make the rest return
+ * "already protected", and the one that succeeded would commit to no content
+ * whatsoever.
+ *
+ * Refusing is the only honest answer. Content that vanishes under text
+ * extraction is not text, and the text pipeline cannot make a claim about it.
+ */
+export class EmptyAfterStrippingError extends Error {
+  constructor() {
+    super(
+      'this content contains no text once markup is removed. ' +
+        'Images and scanned pages cannot be registered through the text path — ' +
+        'hashing them here would commit to an empty document.'
+    );
+    this.name = 'EmptyAfterStrippingError';
+  }
+}
+
+/**
+ * SHA-256 of the empty string.
+ *
+ * Never a legitimate registration. Any path producing it has hashed nothing —
+ * and because every such input produces *this* value, they would all collide
+ * into a single meaningless record. Checked as a backstop at the point of
+ * hashing, so a future code path that skips canonicalisation still cannot
+ * register it.
+ */
+export const EMPTY_SHA256 =
+  'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+
 /** Content as submitted, and what was actually hashed. */
 export interface CanonicalContent {
   /** The exact text the hash commits to. */
@@ -125,6 +161,13 @@ export function toPlainText(content: string): CanonicalContent {
   // indentation of a `<pre>` block, which is exactly the content this is
   // supposed to protect.
   text = text.replace(/^(?:[ \t]*\n)+/, '').replace(/(?:\n[ \t]*)+$/, '');
+
+  // Something was submitted and nothing survived. See EmptyAfterStrippingError:
+  // silently hashing the empty string here would collide every image-only
+  // document into one meaningless registration.
+  if (text.trim() === '') {
+    throw new EmptyAfterStrippingError();
+  }
 
   return { text, stripped: true };
 }

--- a/wordpress-plugin/daon-creator-protection/includes/class-daon-client.php
+++ b/wordpress-plugin/daon-creator-protection/includes/class-daon-client.php
@@ -96,6 +96,19 @@ class DAON_Client {
      */
     public function generate_content_hash($content) {
         $normalized = $this->normalize_content($content);
+
+        // Content that vanishes under tag stripping -- a post that is only an
+        // image, a scanned page -- would otherwise hash to the SHA-256 of the
+        // empty string, which every such post shares. The API refuses these;
+        // the plugin must refuse them identically or it will send a hash the
+        // API would never have produced.
+        if ( $content !== '' && trim( $normalized ) === '' ) {
+            return new WP_Error(
+                'daon_no_text_content',
+                __( 'This content has no text once markup is removed. Images and scanned pages cannot be protected through the text path.', 'daon-creator-protection' )
+            );
+        }
+
         $hash = hash('sha256', $normalized);
         return "sha256:{$hash}";
     }

--- a/wordpress-plugin/daon-creator-protection/tests/test-content-hashing.php
+++ b/wordpress-plugin/daon-creator-protection/tests/test-content-hashing.php
@@ -201,11 +201,14 @@ class Test_Content_Hashing extends \PHPUnit\Framework\TestCase {
         $this->assertSame(71, strlen($hash)); // "sha256:" (7) + 64 hex
     }
 
-    public function test_content_with_only_html_tags(): void {
-        // HTML-only content becomes empty after stripping
-        $hash = $this->client->generate_content_hash('<div><span></span></div>');
-        $hash_empty = $this->client->generate_content_hash('');
-        $this->assertSame($hash_empty, $hash);
+    public function test_content_with_only_html_tags_is_refused(): void {
+        // Inverted deliberately. This previously asserted that markup-only
+        // content hashes the same as the empty string -- which is the bug: every
+        // image-only post, scanned page and empty div shared one hash, so the
+        // first registration made the rest collide and the winner committed to
+        // an empty document.
+        $result = $this->client->generate_content_hash('<div><span></span></div>');
+        $this->assertInstanceOf('WP_Error', $result);
     }
 
     public function test_wordpress_shortcodes_preserved(): void {

--- a/wordpress-plugin/daon-creator-protection/tests/test-content-normalization.php
+++ b/wordpress-plugin/daon-creator-protection/tests/test-content-normalization.php
@@ -67,6 +67,35 @@ class Test_Content_Normalization extends \PHPUnit\Framework\TestCase {
         $this->assertSame( $poem, $this->normalize( $poem ) );
     }
 
+    /**
+     * Content that vanishes under stripping must be refused, not hashed.
+     *
+     * An image-only post normalises to the empty string, and hashing that gives
+     * every such post the same SHA-256. They would collide, and the winner would
+     * commit to an empty document.
+     */
+    public function test_image_only_content_is_refused() {
+        $client = new DAON_Client();
+        foreach ( array(
+            '<img src="cliffs.jpg" alt="">',
+            '<figure><img src="page001.tiff"></figure>',
+            '<div><span></span><br></div>',
+        ) as $input ) {
+            $result = $client->generate_content_hash( $input );
+            $this->assertInstanceOf(
+                'WP_Error',
+                $result,
+                "should have refused: {$input}"
+            );
+        }
+    }
+
+    public function test_an_illustrated_page_with_a_caption_still_hashes() {
+        $client = new DAON_Client();
+        $result = $client->generate_content_hash( '<img src="plate1.png"><p>Plate I</p>' );
+        $this->assertSame( 'sha256:' . hash( 'sha256', 'Plate I' ), $result );
+    }
+
     public function test_matches_the_shared_vectors() {
         $path = dirname( __DIR__, 3 ) . '/scripts/content/canonical-vectors.json';
         if ( ! file_exists( $path ) ) {


### PR DESCRIPTION
Found by asking what happens to a `.docx` or PDF containing a picture.

## The bug

An image-only document canonicalises to the empty string and hashes to `e3b0c44298fc1c14…` — **the SHA-256 of nothing.** So does a scanned page. So does a figure with no caption.

```
a photo essay, image only        -> text=""        hash=e3b0c44298fc1c14…
a different photo entirely       -> text=""        hash=e3b0c44298fc1c14…
scanned manuscript page          -> text=""        hash=e3b0c44298fc1c14…
```

Three consequences, each worse than the last:

1. **They collide with each other.** Three unrelated works, one hash.
2. **The first registration makes every later one return "already protected."**
3. **The one that succeeded committed to no content whatsoever** — a certificate attesting to an empty document.

Canonicalisation introduced this. Before it, `<img src="cliffs.jpg">` hashed as those literal bytes and was at least distinct per image. `/protect` validates `.notEmpty()` on the *input*, so markup-only content passes validation and then vanishes.

## The fix

`toPlainText` throws `EmptyAfterStrippingError` when something was submitted and nothing survived. The four endpoints that hash content return **400 `no_text_content`** with an explanation rather than a 500.

Content that disappears under text extraction is not text, and the text pipeline cannot make a claim about it.

**Plus a backstop at the hash site.** `EMPTY_SHA256` is named and refused independently, so a future path that skips canonicalisation still cannot register the hash of no content.

## WordPress

The plugin hashes locally and sends the hash, so it refuses the same inputs with a `WP_Error`. Otherwise WordPress would submit a hash the API would never have produced.

One existing plugin test asserted **exactly this bug** — `test_content_with_only_html_tags` required markup-only content to hash identically to the empty string. Inverted, with the reasoning recorded rather than deleted.

## Unchanged

Empty input still hashes in both implementations. That's a caller explicitly passing nothing rather than content that vanished, and `/protect` rejects it earlier anyway.

## Tests

30 jest, 130 PHPUnit. Covers image-only, scanned pages, script-only, markup carrying no text, and confirms an illustrated page *with* a caption still registers on its caption.

## Not fixed here

Images and binary still have no registration path — that's the open Pillar 2 gap. This change makes the failure loud instead of silent, which is the difference between "we can't do that yet" and "we gave you a certificate for nothing."