### PR TITLE
fix(renovate): drop a reviewers team that cannot exist

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "baseBranches": ["main"],
   "dependencyDashboard": true,
   "labels": ["dependencies"],
-  "reviewers": ["@daon-network/maintainers"],
+  "_comment_reviewers": "daon-network is a user account, not an organisation, so it has no teams. The previous value @daon-network/maintainers used team syntax (@owner/team) and could never resolve. Reviewers are left unset rather than guessed at.",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["every monday at 6am"]


### PR DESCRIPTION
`renovate.json` named `@daon-network/maintainers` as reviewer. That's **team syntax** — `@owner/team-name` — and `daon-network` is a **user account, not an organisation**, so it has no teams and this could never resolve.

```
$ gh api repos/daon-network/daon --jq '.owner.type'
"User"
```

Same fact explains why every `/orgs/daon-network/*` call 404s, and why this account has push but not admin on its own repo.

## But this is not why Renovate has produced nothing

The config declares `"dependencyDashboard": true`. Renovate opens that issue on its **first run**, before proposing any update. There is no such issue and there never has been a Renovate PR — so **it has never run at all.**

That makes it an installation question, not a configuration one. The app needs adding to the `daon-network` account:

```
https://github.com/apps/renovate → Configure → daon-network → Repository access
```

A Dependency Dashboard issue appearing is the signal it worked.

Reviewers are left unset rather than replaced with a guess.