### PR TITLE
docs: a README for the provenance workspace, and an agent page on the site

### DIFF
--- a/docs/design/agent.md
+++ b/docs/design/agent.md
@@ -1,0 +1,109 @@
+---
+layout: default
+title: "Running the Agent"
+description: "What the provenance agent is, how to build and run it, and what it deliberately refuses to do."
+permalink: /design/agent/
+mermaid: true
+---
+# Running the Agent
+
+The agent is the piece a creator actually runs. It watches authoring activity, coalesces it into
+revision leaves, signs them, batches heads and — eventually — gets them witnessed against Bitcoin.
+Everything it holds stays on the creator's machine.
+
+> **Status: pre-`0.1.0`, nothing published.** The wire format is not frozen. The full and honest
+> status table is in [`provenance/README.md`](https://github.com/daon-network/daon/blob/main/provenance/README.md);
+> the short version is that **no head is witnessed yet**, because nothing submits to a calendar.
+
+---
+
+## The shape of it
+
+```mermaid
+flowchart LR
+    E["your editor"] -->|"Unix socket<br/>mode 0600"| A["agentd"]
+    A --> S["local store<br/><i>leaves · blobs · witness state</i>"]
+    A -.->|"the only egress,<br/>not built yet"| O["OpenTimestamps<br/>→ Bitcoin"]
+    A -x|"never"| D["DAON"]
+```
+
+The editor reports **what it observed** — keystrokes, a paste, an import — and asks for commits.
+It never reports what the content *is*, and the agent never sends content anywhere.
+
+---
+
+## Quickstart
+
+```sh
+cargo install --git https://github.com/daon-network/daon daon-provenance-agentd
+
+daon-provenance-agentd --store ~/.daon/provenance --socket /tmp/daon-agent.sock
+```
+
+No package registry is involved; `cargo` installs from git directly. Pin with `--tag` or `--rev`
+for anything reproducible.
+
+On first run it creates a signing identity and prints a **recovery key, once**. Put it somewhere
+the signing key is not — and if the machine belongs to an employer, read
+[`key-recovery.md`]({{ '/design/key-recovery/' | relative_url }}) § *Custody domains* first.
+
+**If it refuses to start**, the usual cause is the socket path. Operating systems cap these at 104
+bytes (macOS) or 108 (Linux), and the default socket sits inside your store, so a deeply nested
+store makes the daemon unstartable. Pass a short `--socket`.
+
+---
+
+## Talking to it
+
+Any HTTP client that can speak to a Unix socket. The contract is normative in
+[`editor-integration-spec.md`]({{ '/design/editor-integration-spec/' | relative_url }}) §3.
+
+```sh
+curl --unix-socket /tmp/daon-agent.sock -X POST \
+     http://localhost/v1/session/open -d '{"tool_id":"my-editor/1.0"}'
+```
+
+Four routes: `session/open`, `observe`, `commit`, and `entity/{id}/proof`.
+
+**Two things integrators reliably get wrong:**
+
+- **`commit` is a request, not a command.** A `200` carrying `"committed": false` means the agent
+  coalesced your request into the current window. That is the system working. An editor that
+  treats it as an error has misread the contract — see the spec, §4.
+- **A newly committed head reports `"witness_state": "pending"`.** That is correct for minutes to
+  hours afterwards. It is not a failure and should not be surfaced as one.
+
+---
+
+## What it refuses to do
+
+These are load-bearing, not oversights:
+
+- **No TCP.** A Unix socket, mode `0600`, and no flag to change it. *"A debug flag that opens a
+  port is a debug flag that ships."*
+- **No content leaves the machine.** The agent's only egress is OpenTimestamps, and what goes
+  there is a batch root — 32 bytes committing to a set of heads.
+- **No clock is trusted.** Witness time comes from a Bitcoin block header. The agent's own clock
+  decides only when to make a request.
+- **No hashed bytes are normalised.** A normalised hash would depend on the Unicode revision the
+  implementation was built against, and would stop verifying after a library upgrade.
+
+---
+
+## Building from source
+
+```sh
+cd provenance
+rustup toolchain install     # honours rust-toolchain.toml
+cargo test --all-features
+```
+
+The toolchain is pinned because the verifier's value depends on a skeptic rebuilding it and
+getting the same bytes, which is not true if the compiler floats.
+
+Two worked examples explain the cryptography with real values rather than prose:
+
+```sh
+cargo run -p daon-provenance-core --example explain   # Merkle proofs, step by step
+cargo run -p daon-provenance-core --example link      # how commit, leaf, head and batch stack
+```

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -25,6 +25,12 @@ evidence. Anyone should be able to read what we decided, see the reasoning, and 
 | [Data model]({{ '/design/provenance-data-model/' \| relative_url }}) | Leaves, heads and witnesses — what the ledger is and what each part proves |
 | [Registry and provenance]({{ '/design/registry-and-provenance/' \| relative_url }}) | Two systems with two anchors, and why nothing should keep them in sync |
 
+## The agent
+
+| | |
+| --- | --- |
+| [Running the agent]({{ '/design/agent/' \| relative_url }}) | Build it, run it, talk to it — and what it deliberately refuses to do |
+
 ## Format
 
 | | |

--- a/provenance/README.md
+++ b/provenance/README.md
@@ -1,0 +1,198 @@
+# DAON Provenance
+
+An append-only, witnessed record of how a work came to exist — held by the creator, anchored to
+Bitcoin, verifiable by a stranger without trusting DAON.
+
+This directory is a Rust workspace of five crates. The design documents live in
+[`docs/design/`](../docs/design/); this file is how to build and run the thing.
+
+> **Status: pre-`0.1.0`, not published.** Every crate is `version = "0.0.0"` because the wire
+> format is not frozen. See [What is missing](#what-is-missing) before depending on any of it.
+
+---
+
+## The crates
+
+```
+core ──── verify        the format, and the four steps that check it
+  │
+  ├────── witness       OpenTimestamps proofs, batching, Bitcoin anchors
+  │
+  └────── agent ─────── agentd
+          the store     the daemon an editor talks to
+```
+
+| Crate | Does | Depends on |
+| --- | --- | --- |
+| [`core`](core/) | Leaf encoding, the Merkle log, inclusion proofs. The normative format | — |
+| [`verify`](verify/) | The four-step verifier. `no_std`-capable, builds for `wasm32` | core |
+| [`witness`](witness/) | `.ots` parsing, head batching, turning a proof into a Bitcoin anchor | core |
+| [`agent`](agent/) | On-disk store, keychain signer, coalescing policy, witness state | core, witness |
+| [`agentd`](agentd/) | The daemon: a Unix socket serving the editor API | all of the above |
+
+### What each one refuses to do
+
+The boundaries are deliberate and worth knowing before you go looking for a function that is not
+there.
+
+- **Nothing opens a socket except `agentd`,** and it opens exactly one: a Unix domain socket, mode
+  `0600`. There is no TCP option. Submitting to a calendar and fetching Bitcoin headers are the
+  caller's job, behind traits this workspace does not implement.
+- **Nothing reads a clock for evidence.** Witness time comes from a Bitcoin block header. Local
+  time appears in a leaf as `local_time_ms`, explicitly untrusted and signed `i64` so it can hold
+  nonsense without panicking.
+- **Nothing normalises hashed bytes.** No Unicode folding, no line-ending translation. A
+  normalised hash would depend on which Unicode revision the implementation was built against.
+- **`verify` never asks whether a key legitimately changed.** It checks a signature against the
+  `author_key` committed in that leaf. Key rotation is an audit question answered by walking the
+  chain, deliberately not a fifth step.
+
+---
+
+## Build and test
+
+The toolchain is pinned in [`rust-toolchain.toml`](rust-toolchain.toml) — `rustup` reads it, so
+there is nothing to select:
+
+```sh
+cd provenance
+rustup toolchain install     # honours the pin, installs components and the wasm target
+cargo test --all-features
+```
+
+The keychain tests are `#[ignore]` by default because they write real credentials into the
+machine's keychain. To run them against a throwaway one, as CI does:
+
+```sh
+security create-keychain -p "" ci.keychain
+security unlock-keychain  -p "" ci.keychain
+security default-keychain -s ci.keychain
+
+cargo test -p daon-provenance-agent --features keychain -- --ignored --test-threads=1
+
+security delete-keychain ci.keychain
+```
+
+The verifier must keep building for the browser, since its value depends on a skeptic being able
+to run it without trusting a binary we shipped:
+
+```sh
+cargo build -p daon-provenance-verify --target wasm32-unknown-unknown --release
+```
+
+### Worked examples
+
+```sh
+cargo run -p daon-provenance-core --example explain   # what a Merkle proof is, with real hashes
+cargo run -p daon-provenance-core --example link      # how content_commit, leaf, head and batch stack
+cargo run -p daon-provenance-core --example vectors   # emit the §9 wire-format test vectors
+```
+
+---
+
+## Running the daemon
+
+```sh
+cargo run -p daon-provenance-agentd -- \
+    --store ~/.daon/provenance \
+    --socket /tmp/daon-agent.sock
+```
+
+| Flag | Default | |
+| --- | --- | --- |
+| `--store` | *required* | where leaves, blobs and witness state live |
+| `--socket` | `<store>/agent.sock` | **keep it short** — see below |
+| `--identity` | `default` | which keychain identity signs |
+
+On first run it creates a signing identity and prints a **recovery key, once**. Write it down
+somewhere the signing key is not, and see [`key-recovery.md`](../docs/design/key-recovery.md)
+§ *Custody domains* before deciding where — particularly if the machine belongs to an employer.
+
+**There is no `--port`, deliberately.** The spec's reasoning: *"a debug flag that opens a port is
+a debug flag that ships."*
+
+**Socket paths are capped by the operating system** at 104 bytes on macOS and 108 on Linux. Since
+the default socket lives inside the store, a deep store path makes the daemon unstartable. It
+reports this with the length, the limit and the flag to use, but the short version is: if your
+store is nested, pass `--socket /tmp/daon-agent.sock`.
+
+### Talking to it
+
+Any HTTP client that speaks to a Unix socket. The full contract is
+[`editor-integration-spec.md`](../docs/design/editor-integration-spec.md) §3.
+
+```sh
+S=$(curl -s --unix-socket /tmp/daon-agent.sock -X POST \
+      http://localhost/v1/session/open \
+      -d '{"tool_id":"my-editor/1.0"}' | jq -r .session)
+
+curl -s --unix-socket /tmp/daon-agent.sock -X POST http://localhost/v1/observe \
+  -d "{\"session\":\"$S\",\"ingress\":\"keystroke_stream\",
+       \"span_bytes\":{\"added\":412,\"removed\":18},
+       \"op_count\":167,\"duration_ms\":92000}"
+
+curl -s --unix-socket /tmp/daon-agent.sock -X POST http://localhost/v1/commit \
+  -d "{\"session\":\"$S\",\"content\":\"the manuscript\",\"reason\":\"explicit\"}"
+```
+
+Two things integrators get wrong:
+
+- **`commit` is a request, not a command.** A `200` with `"committed": false` means the agent
+  coalesced, which is normal. Treating it as an error is a misreading of the contract.
+- **A fresh head is `"witness_state": "pending"`.** That is the correct state for minutes to
+  hours after writing, not a failure.
+
+---
+
+## Installing
+
+`cargo` installs straight from git — **no package registry is required**:
+
+```sh
+cargo install --git https://github.com/daon-network/daon daon-provenance-agentd
+```
+
+Pin it with `--tag` or `--rev` for anything reproducible.
+
+### Why nothing is on crates.io yet
+
+The wire format is not frozen, and publishing invites people to build against bytes that may
+change. Version `0.0.0` says so.
+
+There is one thing git installs cannot do, and it decides when publishing becomes necessary: **a
+crate published to crates.io may not depend on a git dependency.** So as long as we are unpublished,
+nobody else can publish a crate that builds on the verifier. They can vendor it or depend on it by
+git in an application, but not release a library against it. When that becomes something we want,
+the format has to be frozen first.
+
+### Distribution to creators is a different problem
+
+`cargo install` requires a Rust toolchain, which is not a reasonable thing to ask a novelist for.
+The eventual answer is signed application bundles, and the requirement is not only convenience:
+macOS grants keychain access **per code signature**, and `cargo` re-signs ad-hoc on every rebuild,
+so an unsigned agent asks the creator for permission every time it starts. See
+[`keystore.rs`](agent/src/keystore.rs) — an unsigned build is unusable in daily practice
+regardless of entitlements.
+
+---
+
+## What is missing
+
+Honest status, because the crate docs describe intent and this describes reality.
+
+| | State |
+| --- | --- |
+| Wire format, Merkle log, inclusion proofs | **Works.** Cross-checked against a Python reference on 18 vectors in CI |
+| The four-step verifier | **Works.** Builds for `wasm32` |
+| Store, keychain signer, coalescing policy | **Works** |
+| `.ots` parsing, batching, anchor establishment | **Works**, offline |
+| The daemon and its four routes | **Works** |
+| **Submitting to a calendar** | **Missing.** Nothing reaches OpenTimestamps, so **no head is witnessed yet** |
+| **A Bitcoin header source** | **Missing.** `BlockSource` has no implementation here |
+| **Rotation and transfer leaves** | **Missing.** Designed, decided, unbuilt |
+| **Reading content back out of the store** | **Missing.** Segments are stored by hash with no manifest recording their order |
+| **Binary and image registration** | **Missing.** Text only |
+
+The first two are the ones that matter most. Until a batch root reaches a calendar and a header
+source can resolve it, the chain proves *sequence* but not *time* — and time is the entire claim.
+Everything else here is machinery around that.

--- a/provenance/core/Cargo.toml
+++ b/provenance/core/Cargo.toml
@@ -13,3 +13,6 @@ sha2.workspace = true
 [features]
 default = ["std"]
 std = []
+
+[dev-dependencies]
+sha2.workspace = true

--- a/provenance/core/examples/explain.rs
+++ b/provenance/core/examples/explain.rs
@@ -1,0 +1,98 @@
+//! A walk through what a Merkle root is and what a proof of inclusion buys.
+use daon_provenance_core::{
+    inclusion_proof, merkle_leaf, merkle_root, node, verify_inclusion, Side,
+};
+
+fn short(h: &[u8; 32]) -> String {
+    h[..4].iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn main() {
+    // Four chunks of a manuscript.
+    let chunks: [&[u8]; 4] = [
+        b"It was the best of times,",
+        b"it was the worst of times,",
+        b"it was the age of wisdom,",
+        b"it was the age of foolishness,",
+    ];
+
+    let leaves: Vec<_> = chunks.iter().map(|c| merkle_leaf(c)).collect();
+
+    println!("Each chunk is hashed on its own:\n");
+    for (i, (c, l)) in chunks.iter().zip(&leaves).enumerate() {
+        println!("  L{i}  {}…   \"{}\"", short(l), String::from_utf8_lossy(c));
+    }
+
+    let n01 = node(&leaves[0], &leaves[1]);
+    let n23 = node(&leaves[2], &leaves[3]);
+    let root = merkle_root(&leaves);
+
+    println!("\nPairs are hashed together, then those pairs, until one hash is left:\n");
+    println!("              ROOT {}…", short(&root));
+    println!("             /            \\");
+    println!("      {}…              {}…", short(&n01), short(&n23));
+    println!("      /      \\            /      \\");
+    println!(
+        "  {}…  {}…    {}…  {}…",
+        short(&leaves[0]),
+        short(&leaves[1]),
+        short(&leaves[2]),
+        short(&leaves[3])
+    );
+    println!("   L0      L1        L2      L3");
+
+    // Prove L2 belongs, without handing over L0, L1 or L3.
+    let proof = inclusion_proof(&leaves, 2);
+    println!("\n─── Proving chunk 2 is in there ───\n");
+    println!("You reveal:  \"{}\"", String::from_utf8_lossy(chunks[2]));
+    println!("Plus {} sibling hashes:", proof.len());
+    for (side, h) in &proof {
+        println!("     {:?}  {}…", side, short(h));
+    }
+
+    println!("\nThe verifier recomputes upward:");
+    let mut cur = merkle_leaf(chunks[2]);
+    println!("     hash the chunk              -> {}…", short(&cur));
+    for (side, sib) in &proof {
+        cur = match side {
+            Side::Left => node(sib, &cur),
+            Side::Right => node(&cur, sib),
+        };
+        println!("     combine with {:?} sibling  -> {}…", side, short(&cur));
+    }
+    println!("\n     computed {}…", short(&cur));
+    println!("     expected {}…   match: {}", short(&root), cur == root);
+
+    println!("\nWhat the verifier did NOT learn:");
+    for (i, c) in chunks.iter().enumerate() {
+        if i != 2 {
+            println!(
+                "     chunk {i}: \"{}\"  — never sent, only its hash",
+                String::from_utf8_lossy(c)
+            );
+        }
+    }
+
+    // Substitution must fail.
+    let forged = verify_inclusion(&merkle_leaf(b"it was the age of DIFFERENT,"), &proof, &root);
+    println!(
+        "\nSwapping the chunk for different text and reusing the proof: {}",
+        if forged {
+            "VERIFIES — broken!"
+        } else {
+            "fails, as it must"
+        }
+    );
+
+    println!("\nProof size grows with the logarithm of the number of chunks:");
+    for n in [4usize, 1_024, 1_048_576] {
+        let leaves: Vec<_> = (0..n)
+            .map(|i| merkle_leaf(&(i as u32).to_be_bytes()))
+            .collect();
+        println!(
+            "     {:>9} chunks -> {} hashes to prove one",
+            n,
+            inclusion_proof(&leaves, 0).len()
+        );
+    }
+}

--- a/provenance/core/examples/link.rs
+++ b/provenance/core/examples/link.rs
@@ -1,0 +1,75 @@
+use daon_provenance_core::*;
+fn s(h: &[u8; 32]) -> String {
+    h[..6].iter().map(|b| format!("{b:02x}")).collect()
+}
+fn main() {
+    let work = b"It was the best of times, it was the worst of times.";
+
+    // ── What the REGISTRY computes ──
+    use sha2::{Digest, Sha256};
+    let registry_hash: [u8; 32] = Sha256::digest(work).into();
+
+    // ── What PROVENANCE computes, from the same bytes ──
+    let commit = content_commit(work);
+
+    println!("Same bytes, two independent computations:\n");
+    println!(
+        "  registry  content_hash    {}…   plain SHA-256 of the text",
+        s(&registry_hash)
+    );
+    println!(
+        "  provenance content_commit {}…   Merkle root over 1 KiB segments",
+        s(&commit)
+    );
+    println!(
+        "\n  equal? {}   <- they are NOT the same number, and never were",
+        registry_hash == commit
+    );
+
+    println!("\n─── Where content_commit DOES get re-committed ───\n");
+    let obs = Observation {
+        tool_id: b"editor".to_vec(),
+        ingress: Ingress::KeystrokeStream,
+        added: 52,
+        removed: 0,
+        duration_ms: 9000,
+        op_count: 30,
+    };
+    let leaf = RevisionLeaf {
+        seq: 0,
+        parent_head: [0; 32],
+        content_commit: commit,
+        meta_commit: meta_commit(&[obs]).unwrap(),
+        beacon: Beacon {
+            chain: BeaconChain::Bitcoin,
+            height: 800_000,
+            block_hash: [0x42; 32],
+        },
+        author_key: [0xaa; 32],
+        recovery_key: [0xbb; 32],
+        local_time_ms: 1_700_000_000_000,
+    };
+    let leaf_id = leaf.leaf_id();
+    let head = merkle_root(&[leaf_id]);
+    let batch_root = merkle_root(&[head, [0x11; 32], [0x22; 32]]);
+
+    println!(
+        "  content_commit {}…  sits INSIDE the 218-byte leaf, at offset 41",
+        s(&commit)
+    );
+    println!(
+        "        leaf_id  {}…  = hash of that whole leaf body",
+        s(&leaf_id)
+    );
+    println!(
+        "           head  {}…  = Merkle root over the entity's leaf_ids",
+        s(&head)
+    );
+    println!(
+        "     batch root  {}…  = Merkle root over many heads",
+        s(&batch_root)
+    );
+    println!("                        ^ this is what goes to OpenTimestamps");
+
+    println!("\n  Each one commits to the one above it. The registry hash is in none of them.");
+}


### PR DESCRIPTION
The reference documentation was strong; the orientation documentation didn't exist.

~975 lines of rustdoc explain *why* the protected store needs a signed app and *why* the OTS fork marker is a trap. But nothing said what the five crates are, how to build them, or how to get something listening on a socket. **`agentd` was mentioned nowhere outside its own source** — not in the design index, not on the site, not in the root README. Someone handed this repo had no way to discover it exists.

## `provenance/README.md`

What each crate does and depends on. What each **refuses** to do — no TCP, no clock trusted for evidence, no normalised hashed bytes, and `verify` never asking whether a key legitimately changed. How to build and test, including the throwaway-keychain recipe CI uses. How to run the daemon, including the socket-path length trap.

And an honest status table, which matters more than the rest — the crate docs describe intent, and a reader deserves to know that **nothing submits to a calendar yet**, so the chain currently proves *sequence* but not *time*.

## `docs/design/agent.md`

Site page, linked from the design index. Quickstart plus the two things integrators reliably get wrong:

- **`commit` is a request, not a command.** A `200` with `"committed": false` means the agent coalesced. That's the system working.
- **A fresh head is `"witness_state": "pending"`.** Correct for hours. Not a failure.

## On distribution

Answered in both: **`cargo` installs directly from git, no registry required.**

```sh
cargo install --git https://github.com/daon-network/daon daon-provenance-agentd
```

The constraint worth knowing: **a crate published to crates.io may not depend on a git dependency.** So while we're unpublished, nobody else can release a library built on the verifier — they can vendor it or depend by git in an application, but not publish against it. That's what will eventually force publishing, and it needs the wire format frozen first.

Distribution to *creators* is a separate problem again. `cargo install` wants a Rust toolchain, which isn't reasonable to ask a novelist for — and macOS grants keychain access **per code signature**, so an unsigned agent asks permission every time it starts. Signed bundles aren't a nicety there.

Every command in both documents was run before committing.