### PR TITLE
fix(deploy): target the project the running containers actually belong to

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -222,7 +222,7 @@ jobs:
             # Also create in /opt/daon for any services that reference it
             cp /opt/daon-source/.env /opt/daon/.env
             
-            # Navigate to source directory where docker-compose.yml is
+            # Build from the freshly rsynced source.
             cd /opt/daon-source
             
             # Fix blockchain volume permissions (UID 1000 = daon user in container)
@@ -238,14 +238,40 @@ jobs:
             # Build blockchain image locally
             docker build -t daon-blockchain:latest ./daon-core
 
+            # Compose must run against the project the live containers belong to.
+            #
+            # Docker derives a project name from the working directory, so running
+            # compose in /opt/daon-source addressed project "daon-source" -- which
+            # has no containers. Every stop, rm and up hit an empty project, the
+            # "|| true" swallowed the errors, and the running stack was untouched
+            # for three months while builds succeeded and the job reported green.
+            #
+            # -p pins the project explicitly so the directory stops deciding it.
+            COMPOSE="docker compose -p daon -f /opt/daon/docker-compose.yml --project-directory /opt/daon"
+
             # Stop and remove app containers so new images are guaranteed to run
             # (--force-recreate is unreliable when container_name is set)
-            # Service names must match docker-compose.yml (daon-api-1, daon-api-3, etc.)
-            docker compose stop daon-api-1 daon-api-3 daon-frontend daon-blockchain 2>/dev/null || true
-            docker compose rm -f daon-api-1 daon-api-3 daon-frontend daon-blockchain 2>/dev/null || true
+            $COMPOSE stop daon-api-1 daon-api-3 daon-frontend daon-blockchain 2>/dev/null || true
+            $COMPOSE rm -f daon-api-1 daon-api-3 daon-frontend daon-blockchain 2>/dev/null || true
 
             # Deploy full stack
-            docker compose up -d --remove-orphans
+            $COMPOSE up -d --remove-orphans
+
+            # Assert the containers actually picked up what was just built.
+            #
+            # A health check cannot catch this: the stale container answers
+            # /health perfectly well, which is exactly how three months of
+            # no-op deploys stayed green. Compare image IDs instead.
+            built=$(docker image inspect daon-api:latest --format "{{.Id}}")
+            for c in daon-api-1 daon-api-3; do
+              running=$(docker inspect "$c" --format "{{.Image}}")
+              if [ "$running" != "$built" ]; then
+                echo "::error::$c is running $running but daon-api:latest is $built -- the deploy did not take"
+                docker compose -p daon ps
+                exit 1
+              fi
+              echo "  $c is running the image just built"
+            done
             
             # Run database migrations (all are idempotent via IF NOT EXISTS)
             echo "⏳ Waiting for postgres to be ready..."


### PR DESCRIPTION
**Production has been serving three-month-old code while every deploy reported success.**

```json
"uptime": 8242028        // 95 days
```

`POST /api/v1/verify-content` with `<p>Hello</p>` returns `d0a26d23…` — SHA-256 of the raw string — not `185f8db3…`, which is `Hello` canonicalised. So **nothing from #115 or #117 was ever live.**

## Cause

Docker derives a compose project name from the working directory.

```
live containers:      project=daon         working_dir=/opt/daon
deploy ran compose:   project=daon-source  (cd /opt/daon-source)

from /opt/daon-source → docker compose ps lists NOTHING
from /opt/daon        → lists all six running
```

Every `stop`, `rm` and `up -d` hit an empty project. The `2>/dev/null || true` on the stop/rm lines — there to tolerate a first deploy — swallowed every "no such service", `up -d` had nothing to create, and the freshly built image sat unused:

```
daon-api-1, daon-api-3   image e0f4f1feafd4   up 3 months
daon-api:latest          created 32 hours ago      ← built, never used
```

## Fix

Pin the project with `-p daon` and point compose at `/opt/daon` explicitly, so the working directory stops deciding which containers get touched. Builds still run from the rsynced source; only the compose invocations move.

**Plus the check that would have caught this on day one.** A health check can't: the stale container answers `/health` perfectly well, which is exactly how three months of no-op deploys stayed green. The deploy now compares each running container's image ID against the image just built, and fails loudly if they differ.

Verified against the live server before committing — the pinned command lists all six containers from the same directory where the unpinned one lists none.

## One silver lining

Because the deploy has been broken since May, **the empty-hash collision bug never reached production.** It was introduced in #115, which never shipped. Merging this lands #115 and #117 together, so canonicalisation and its refusal arrive at the same moment — there's no window where the collision is live.

The legacy-hash fallback in #117 becomes genuinely load-bearing at that point: every existing registration was made under raw hashing, and verification needs to keep accepting those.