### PR TITLE
feat(ops): make a stale deploy and a hung job visible

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
   # Pre-deployment validation gate
   validate-deployment:
     name: Validate Deployment Readiness
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -63,6 +64,7 @@ jobs:
   security-audit:
     needs: [validate-deployment]
     name: Security Audit
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -93,6 +95,7 @@ jobs:
   # Test API (but don't push to Docker Hub)
   test-api:
     name: Test API
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: [validate-deployment, security-audit]
     steps:
@@ -118,6 +121,7 @@ jobs:
   # Build and push VALIDATOR image (public for network participants)
   build-validator:
     name: Build Validator Image
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: [security-audit]
     outputs:
@@ -165,6 +169,7 @@ jobs:
   # Deploy to Production
   deploy:
     name: Deploy to Production
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     needs: [test-api, build-validator]
     if: github.ref == 'refs/heads/main'
@@ -229,8 +234,12 @@ jobs:
             sudo mkdir -p /opt/daon-database/blockchain
             sudo chown -R 1000:1000 /opt/daon-database/blockchain
             
-            # Build API locally (not pushed to Docker Hub)
-            docker build -t daon-api:latest ./api-server
+            # Build API locally (not pushed to Docker Hub).
+            # The commit is baked in so /health can report which build is running.
+            docker build \
+              --build-arg GIT_COMMIT="${{ github.sha }}" \
+              --build-arg BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              -t daon-api:latest ./api-server
 
             # Build frontend locally
             docker build -t daon-frontend:latest ./daon-frontend
@@ -272,6 +281,18 @@ jobs:
               fi
               echo "  $c is running the image just built"
             done
+
+            # And confirm the *served* build is this commit, not merely that the
+            # container was replaced. This is the check that would have caught
+            # three months of no-op deploys on day one.
+            sleep 5
+            served=$(curl -fsS https://api.daon.network/health | \
+                     python3 -c "import sys,json; print(json.load(sys.stdin).get('build',{}).get('commit','missing'))")
+            if [ "$served" != "${{ github.sha }}" ]; then
+              echo "::error::/health reports build $served but this deploy is ${{ github.sha }}"
+              exit 1
+            fi
+            echo "  /health reports ${served:0:8} -- the deployed build is this commit"
             
             # Run database migrations (all are idempotent via IF NOT EXISTS)
             echo "⏳ Waiting for postgres to be ready..."
@@ -323,6 +344,7 @@ jobs:
   # Notification
   notify:
     name: Deployment Notification
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: [deploy]
     if: always()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,7 @@ jobs:
   # Detect which areas of the repo changed so downstream jobs can self-select
   changes:
     name: Detect Changes
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     outputs:
       api_server: ${{ steps.filter.outputs.api_server }}
@@ -66,6 +67,7 @@ jobs:
 
   security:
     name: Security Audit
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.api_server == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -88,6 +90,7 @@ jobs:
 
   test:
     name: API Tests (Node ${{ matrix.node-version }})
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.api_server == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -111,6 +114,7 @@ jobs:
 
   build-test:
     name: API Docker Build
+    timeout-minutes: 15
     needs: [changes, security, test]
     # Only run when api-server changed AND both gating jobs passed
     if: |
@@ -144,6 +148,7 @@ jobs:
 
   blockchain-build-test:
     name: Blockchain Build
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.blockchain == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -169,6 +174,7 @@ jobs:
 
   blockchain-docker-build:
     name: Blockchain Docker Build
+    timeout-minutes: 15
     needs: [changes, blockchain-build-test]
     # Builds the real validator image from the same context deploy.yml uses, so
     # a Dockerfile, toolchain or dependency-resolution failure surfaces here
@@ -204,6 +210,7 @@ jobs:
 
   frontend-test:
     name: Frontend Build & E2E
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -236,6 +243,7 @@ jobs:
 
   provenance:
     name: Provenance (Rust)
+    timeout-minutes: 20
     needs: changes
     if: needs.changes.outputs.provenance == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -312,6 +320,7 @@ jobs:
 
   wordpress:
     name: WordPress Plugin Tests
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.wordpress == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -339,6 +348,7 @@ jobs:
 
   ccc-build:
     name: creative-commons-chain Build
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.ccc == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -354,6 +364,7 @@ jobs:
 
   test-go:
     name: Go SDK Tests
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.sdk_go == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -367,6 +378,7 @@ jobs:
 
   test-node-sdk:
     name: Node.js SDK Tests
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.sdk_node == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -383,6 +395,7 @@ jobs:
 
   test-python:
     name: Python SDK Tests
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.sdk_python == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -397,6 +410,7 @@ jobs:
 
   test-ruby:
     name: Ruby SDK Tests
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.sdk_ruby == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -412,6 +426,7 @@ jobs:
 
   test-php:
     name: PHP SDK Tests
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.sdk_php == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -432,6 +447,7 @@ jobs:
 
   provenance-keychain:
     name: Provenance (macOS keychain)
+    timeout-minutes: 20
     needs: changes
     if: needs.changes.outputs.provenance == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: macos-latest
@@ -480,6 +496,7 @@ jobs:
 
   docs:
     name: Docs Site Build
+    timeout-minutes: 10
     needs: changes
     if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
@@ -555,6 +572,7 @@ jobs:
 
   pr-summary:
     name: PR Summary
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs:
       - changes

--- a/api-server/Dockerfile
+++ b/api-server/Dockerfile
@@ -26,6 +26,14 @@ RUN mkdir -p logs && \
 USER nodejs
 
 # Expose port
+# Build identity, surfaced by /health so a stale deployment is detectable at all.
+# Without it every build looks identical from outside and a container serving
+# months-old code passes every liveness check there is.
+ARG GIT_COMMIT=unknown
+ARG BUILD_TIME=unknown
+ENV GIT_COMMIT=$GIT_COMMIT
+ENV BUILD_TIME=$BUILD_TIME
+
 EXPOSE 3000
 
 # Health check

--- a/api-server/src/server.ts
+++ b/api-server/src/server.ts
@@ -318,6 +318,20 @@ app.get('/health', async (req, res) => {
     instance: process.env.INSTANCE_ID || 'unknown',
     timestamp: new Date().toISOString(),
     version: '0.1.0',
+    // Build identity, injected at image build time.
+    //
+    // `version` is the package version and cannot distinguish May's build from
+    // today's -- which is exactly how a container ran three-month-old code for
+    // three months while every deploy reported success and every liveness check
+    // passed. A stale container is perfectly healthy; it is just wrong, and
+    // nothing that only asks "is it up" can see that.
+    //
+    // "unknown" means the image was built without the build arg, which is
+    // itself worth noticing.
+    build: {
+      commit: process.env.GIT_COMMIT || 'unknown',
+      builtAt: process.env.BUILD_TIME || 'unknown',
+    },
     blockchain: blockchainEnabled ? {
       enabled: true,
       connected: blockchainStatus?.connected || false,
@@ -352,6 +366,20 @@ app.get('/api/v1', (req, res) => {
   res.json({
     name: 'DAON API',
     version: '0.1.0',
+    // Build identity, injected at image build time.
+    //
+    // `version` is the package version and cannot distinguish May's build from
+    // today's -- which is exactly how a container ran three-month-old code for
+    // three months while every deploy reported success and every liveness check
+    // passed. A stale container is perfectly healthy; it is just wrong, and
+    // nothing that only asks "is it up" can see that.
+    //
+    // "unknown" means the image was built without the build arg, which is
+    // itself worth noticing.
+    build: {
+      commit: process.env.GIT_COMMIT || 'unknown',
+      builtAt: process.env.BUILD_TIME || 'unknown',
+    },
     description: 'Creator protection API for blockchain-verified content ownership',
     endpoints: {
       'POST /api/v1/protect': 'Protect content with Liberation License',

--- a/monitoring/alert_rules.yml
+++ b/monitoring/alert_rules.yml
@@ -392,3 +392,47 @@ groups:
 # 6. Documentation:
 #    - Keep runbook links in annotations
 #    - Document expected values and thresholds
+
+  # ── Deployment correctness ────────────────────────────────────────────────
+  #
+  # Every rule above asks whether something is *down*. None of them can see a
+  # container that is up, healthy, fast, and running code from three months ago
+  # -- which is precisely what happened: builds succeeded, deploys reported
+  # green, liveness checks passed, and production served stale code the whole
+  # time.
+  #
+  # These need the api to expose its build commit, which /health now does.
+  - name: deployment
+    rules:
+      - alert: DeployedBuildUnknown
+        expr: daon_build_info{commit="unknown"} == 1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "API is running an image built without a commit stamp"
+          description: >
+            The image was built outside the deploy pipeline, so there is no way
+            to tell what code is running.
+
+      - alert: DeployedBuildStale
+        expr: time() - daon_build_timestamp_seconds > 2592000
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "API build is over 30 days old"
+          description: >
+            Not necessarily wrong -- a quiet month is fine -- but worth
+            confirming deliberately rather than discovering after three months.
+
+      - alert: APIRestartedUnexpectedly
+        expr: time() - process_start_time_seconds < 300
+        for: 0m
+        labels:
+          severity: info
+        annotations:
+          summary: "API process started within the last 5 minutes"
+          description: >
+            Expected during a deploy. Outside one it means a crash loop or an
+            OOM kill, neither of which any liveness rule would report.


### PR DESCRIPTION
Two incidents this week were both silent, and **neither could have been caught by anything currently running.**

## The hung job

50 minutes with every later step pending. **No job in `pr.yml` or `deploy.yml` had a timeout**, so the ceiling was GitHub's default of six hours.

All 24 now have one, sized well above real runtimes so they fire only on something genuinely stuck. A hang becomes a failure, and a failure notifies.

## The stale deploy

Three months of green deploys without replacing a container. Nothing could see it: `/health` reported `version: 0.1.0` — the *package* version, which cannot distinguish May's build from today's.

`/health` now reports the commit and build time, injected as Docker build args by the deploy:

```json
"build": { "commit": "a1b2c3…", "builtAt": "2026-08-19T04:12:00Z" }
```

`"unknown"` means the image was built outside the pipeline, which is itself worth noticing.

And the deploy now asserts the **served** build is this commit — not merely that a container was replaced, which is the weaker claim the image-ID check already makes.

## Why the existing alerts couldn't help

`monitoring/alert_rules.yml` has 30 rules. **Every one asks whether something is down.**

A container running three-month-old code is up, healthy, fast, and wrong. It passes all 30. Liveness monitoring is structurally blind to deployment correctness.

New `deployment` group asks the other question — is what's running what was shipped:

| Alert | Catches |
|---|---|
| `DeployedBuildUnknown` | image built outside the pipeline |
| `DeployedBuildStale` | build over 30 days old |
| `APIRestartedUnexpectedly` | crash loop or OOM kill outside a deploy |

## One thing this does not fix

**Those rules are not evaluated by anything.** Production runs six containers and Prometheus is not among them, so 33 rules now exist and none fire.

Wiring the monitoring stack is a bigger call than this change makes. The rules being ready is not the same as the alerting working — which is the same pattern as `getVersionHistory`, `normalized_hash` and `content_versions`: built, never connected.