### PR TITLE
feat(provenance): reach OpenTimestamps, and run the loop that does it

### DIFF
--- a/provenance/Cargo.lock
+++ b/provenance/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ dependencies = [
  "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -175,6 +175,12 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -232,6 +238,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -349,6 +365,7 @@ version = "0.0.0"
 dependencies = [
  "daon-provenance-agent",
  "daon-provenance-core",
+ "daon-provenance-net",
  "daon-provenance-witness",
  "hex",
  "serde",
@@ -361,6 +378,16 @@ name = "daon-provenance-core"
 version = "0.0.0"
 dependencies = [
  "sha2",
+]
+
+[[package]]
+name = "daon-provenance-net"
+version = "0.0.0"
+dependencies = [
+ "daon-provenance-core",
+ "daon-provenance-witness",
+ "hex",
+ "ureq",
 ]
 
 [[package]]
@@ -390,6 +417,17 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -454,7 +492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -488,6 +526,21 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures-core"
@@ -613,6 +666,110 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +826,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "log"
@@ -786,6 +949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,7 +982,16 @@ dependencies = [
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -918,6 +1096,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ripemd"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,7 +1137,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1068,6 +1295,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1321,18 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "subtle"
@@ -1118,6 +1363,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,7 +1383,17 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1205,7 +1471,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1213,6 +1479,45 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -1283,6 +1588,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,8 +1620,17 @@ dependencies = [
  "byteorder",
  "keyring-core",
  "regex",
- "windows-sys",
+ "windows-sys 0.61.2",
  "zeroize",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
@@ -1311,12 +1643,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
@@ -1347,7 +1772,7 @@ dependencies = [
  "tracing",
  "uds_windows",
  "uuid",
- "windows-sys",
+ "windows-sys 0.61.2",
  "winnow",
  "zbus_macros",
  "zbus_names",
@@ -1421,10 +1846,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "zmij"

--- a/provenance/Cargo.toml
+++ b/provenance/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["core", "verify", "agent", "witness", "agentd"]
+members = ["core", "verify", "agent", "witness", "net", "agentd"]
 
 [workspace.package]
 edition = "2021"
@@ -14,6 +14,7 @@ ed25519-dalek = { version = "2", default-features = false }
 daon-provenance-core = { path = "core", default-features = false }
 daon-provenance-witness = { path = "witness", default-features = false }
 daon-provenance-agent = { path = "agent" }
+daon-provenance-net = { path = "net" }
 hex = "0.4"
 tempfile = "3"
 # Registering the protected (data-protection) store ourselves means talking to

--- a/provenance/README.md
+++ b/provenance/README.md
@@ -193,10 +193,14 @@ Honest status, because the crate docs describe intent and this describes reality
 | The witness loop | **Works.** Runs on a timer from daemon startup; `--no-witness` opts out |
 | The daemon and its four routes | **Works** |
 | Rotation, recovery rotation and transfer | **Works.** Effective at their own `seq` — there is deliberately no delay |
-| **Reading content back out of the store** | **Missing.** Segments are stored by hash with no manifest recording their order |
+| Storing content | **Off by default.** Segments were write-only, and a fixed 1 KiB boundary makes a revision pass cost a full copy of the document. `open_keeping_content` opts in |
 | **Binary and image registration** | **Missing.** Text only |
 
-A chain can now be written, batched, submitted, upgraded and verified end to end. What remains is
-real but no longer load-bearing: an agent that cannot return the content it hashed is a worse
-agent, and one that cannot register a photograph is a narrower one, but neither stops the system
-making the claim it exists to make.
+A chain can now be written, batched, submitted, upgraded and verified end to end.
+
+The creator keeps their own file, which `wire-format.md` §6 already assumed — it has a creator
+generating segment proofs "from content only they hold". A chain costs 282 bytes per revision, so a
+thousand revisions is a few hundred kilobytes.
+
+What remains is binary and image registration, which makes the system narrower rather than
+unfinished.

--- a/provenance/README.md
+++ b/provenance/README.md
@@ -28,34 +28,18 @@ core ──── verify        the format, and the four steps that check it
 | [`verify`](verify/) | The four-step verifier. `no_std`-capable, builds for `wasm32` | core |
 | [`witness`](witness/) | `.ots` parsing, head batching, turning a proof into a Bitcoin anchor | core |
 | [`agent`](agent/) | On-disk store, keychain signer, coalescing policy, witness state | core, witness |
-| [`agentd`](agentd/) | The daemon: a Unix socket serving the editor API | all of the above |
-
-### What the chain cannot do
-
-Stated before the API, because it is the boundary everything else is arranged around:
-
-| | |
-| --- | --- |
-| The chain proves | you wrote this, by this date, and control the keys that signed it |
-| The chain **cannot** | detect a competing fork, or resolve one |
-
-A thief works from a copy, so their rotation and your counter-rotation share a parent and **fork**
-rather than sequence. And no timestamp calendar indexes, so there is no query for what else shares
-a chain's prefix — the other branch is not hidden, there is nowhere to look.
-
-Detecting competing claims needs somewhere they are collected, which is the registry. See
-[`publication-and-versions.md`](../docs/design/publication-and-versions.md). A creator who never
-touches DAON keeps the first row and gets nothing from the second, and that is the trade rather
-than a gap.
+| [`net`](net/) | **The only crate that opens a socket.** Calendar client, block source | core, witness |
+| [`agentd`](agentd/) | The daemon: the editor socket, and the witness loop | all of the above |
 
 ### What each one refuses to do
 
 The boundaries are deliberate and worth knowing before you go looking for a function that is not
 there.
 
-- **Nothing opens a socket except `agentd`,** and it opens exactly one: a Unix domain socket, mode
-  `0600`. There is no TCP option. Submitting to a calendar and fetching Bitcoin headers are the
-  caller's job, behind traits this workspace does not implement.
+- **Only `net` reaches the network, and only `agentd` listens.** The daemon opens one Unix domain
+  socket, mode `0600`, with no TCP option. Everything outbound is in `net`, which exists so the
+  agent's egress is enumerable: a reviewer confirms what can leave the machine by reading one
+  crate. A calendar learns a 32-byte digest and nothing else — not what, not whose, not how large.
 - **Nothing reads a clock for evidence.** Witness time comes from a Bitcoin block header. Local
   time appears in a leaf as `local_time_ms`, explicitly untrusted and signed `i64` so it can hold
   nonsense without panicking.
@@ -203,14 +187,16 @@ Honest status, because the crate docs describe intent and this describes reality
 | Wire format, Merkle log, inclusion proofs | **Works.** Cross-checked against a Python reference on 18 vectors in CI |
 | The four-step verifier | **Works.** Builds for `wasm32` |
 | Store, keychain signer, coalescing policy | **Works** |
-| `.ots` parsing, batching, anchor establishment | **Works**, offline |
+| `.ots` parsing, batching, anchor establishment | **Works** |
+| Calendar submission and upgrade | **Works.** `net` is the only crate that opens a socket |
+| A Bitcoin header source | **Works.** Esplora-compatible, and one implementation among several a caller might prefer |
+| The witness loop | **Works.** Runs on a timer from daemon startup; `--no-witness` opts out |
 | The daemon and its four routes | **Works** |
-| **Submitting to a calendar** | **Missing.** Nothing reaches OpenTimestamps, so **no head is witnessed yet** |
-| **A Bitcoin header source** | **Missing.** `BlockSource` has no implementation here |
 | Rotation, recovery rotation and transfer | **Works.** Effective at their own `seq` — there is deliberately no delay |
 | **Reading content back out of the store** | **Missing.** Segments are stored by hash with no manifest recording their order |
 | **Binary and image registration** | **Missing.** Text only |
 
-The first two are the ones that matter most. Until a batch root reaches a calendar and a header
-source can resolve it, the chain proves *sequence* but not *time* — and time is the entire claim.
-Everything else here is machinery around that.
+A chain can now be written, batched, submitted, upgraded and verified end to end. What remains is
+real but no longer load-bearing: an agent that cannot return the content it hashed is a worse
+agent, and one that cannot register a photograph is a narrower one, but neither stops the system
+making the claim it exists to make.

--- a/provenance/agent/src/lib.rs
+++ b/provenance/agent/src/lib.rs
@@ -138,7 +138,7 @@ pub struct StoredLeaf {
 ///
 /// ```text
 /// <root>/
-///   blobs/<first two hex>/<full hex>     content segments, deduplicated
+///   blobs/<first two hex>/<full hex>     content segments, only when kept
 ///   entities/<entity_id hex>/
 ///     leaves/<seq padded to 20>.leaf     218-byte body
 ///     leaves/<seq padded to 20>.sig      64-byte signature
@@ -149,6 +149,7 @@ pub struct StoredLeaf {
 /// on the next revision. For a manuscript edited in place that is most of it.
 pub struct Store {
     root: PathBuf,
+    keep_content: bool,
 }
 
 fn hex32(h: &Hash) -> String {
@@ -157,11 +158,31 @@ fn hex32(h: &Hash) -> String {
 
 impl Store {
     /// Open or create a store rooted at `path`.
+    /// Open a store. Content segments are **not** kept — see
+    /// [`Store::put_content_with`] for why, and [`Store::open_keeping_content`]
+    /// if you want them.
     pub fn open(path: impl AsRef<Path>) -> Result<Self, Error> {
+        Self::open_with(path, false)
+    }
+
+    /// Open a store that also writes content segments to disk.
+    ///
+    /// Costs a full copy of the document per revision whenever an edit lands
+    /// near the top, because segment boundaries are fixed and a shifted
+    /// boundary makes every later segment new. Nothing in this crate reads the
+    /// segments back yet, so this is storage for a future reader rather than a
+    /// present one.
+    pub fn open_keeping_content(path: impl AsRef<Path>) -> Result<Self, Error> {
+        Self::open_with(path, true)
+    }
+
+    fn open_with(path: impl AsRef<Path>, keep_content: bool) -> Result<Self, Error> {
         let root = path.as_ref().to_path_buf();
-        fs::create_dir_all(root.join("blobs"))?;
+        if keep_content {
+            fs::create_dir_all(root.join("blobs"))?;
+        }
         fs::create_dir_all(root.join("entities"))?;
-        Ok(Store { root })
+        Ok(Store { root, keep_content })
     }
 
     fn blob_path(&self, h: &Hash) -> PathBuf {
@@ -196,12 +217,36 @@ impl Store {
         Ok(())
     }
 
-    /// Store a revision's content, one blob per segment.
+    /// Commit to a revision's content, storing the segments only if asked.
     ///
-    /// Returns the `content_commit` for the whole content. Segments already
-    /// present are not rewritten, so an edit that touches one paragraph costs
-    /// one segment rather than a copy of the manuscript.
-    pub fn put_content(&self, content: &[u8]) -> Result<Hash, Error> {
+    /// Returns the `content_commit` either way — that is what a leaf needs, and
+    /// computing it requires no storage at all.
+    ///
+    /// # Why storing is off by default
+    ///
+    /// It cost a great deal and bought nothing. Segments were written and never
+    /// read: no code path reconstructed content from them, because nothing
+    /// recorded the *order* of a revision's segments, so the bytes were on disk
+    /// with no recipe for reassembling them.
+    ///
+    /// And the cost is worse than it looks. Segment boundaries are fixed at
+    /// 1 KiB, so inserting a character near the top of a document shifts every
+    /// boundary after it and makes every subsequent segment new. Deduplication
+    /// saves nothing on exactly the edit pattern a revision pass produces: a
+    /// 500 KB manuscript revised from the top costs 500 KB *per revision*.
+    ///
+    /// So the default is to commit without storing. A leaf is 282 bytes with its
+    /// signature, so a thousand-revision chain costs a few hundred kilobytes and
+    /// the creator keeps their own file — which `wire-format.md` §6 already
+    /// assumes, since it has a creator generating segment proofs "from content
+    /// only they hold".
+    ///
+    /// Passing `true` restores the old behaviour for a caller who wants it and
+    /// understands the bill.
+    pub fn put_content_with(&self, content: &[u8], store_segments: bool) -> Result<Hash, Error> {
+        if !store_segments {
+            return Ok(content_commit(content));
+        }
         for seg in content.chunks(SEGMENT_SIZE.max(1)) {
             let h = daon_provenance_core::hash_tagged(tag::CONTENT, seg);
             let p = self.blob_path(&h);
@@ -217,6 +262,16 @@ impl Store {
             }
         }
         Ok(content_commit(content))
+    }
+
+    /// Commit to content without storing it. See [`Store::put_content_with`].
+    pub fn put_content(&self, content: &[u8]) -> Result<Hash, Error> {
+        self.put_content_with(content, self.keep_content)
+    }
+
+    /// Whether this store writes content segments to disk.
+    pub fn keeps_content(&self) -> bool {
+        self.keep_content
     }
 
     /// Number of leaves in an entity.

--- a/provenance/agent/tests/store.rs
+++ b/provenance/agent/tests/store.rs
@@ -156,9 +156,14 @@ fn signatures_verify_against_the_committed_author_key() {
         .is_ok());
 }
 
+/// Deduplication of *stored* segments. Storage is off by default now, so this
+/// opens a store that keeps them -- the property still matters for a caller who
+/// opts in.
+
 #[test]
 fn content_segments_are_deduplicated() {
-    let (dir, s) = store();
+    let dir = tempfile::tempdir().unwrap();
+    let s = Store::open_keeping_content(dir.path()).unwrap();
     let big = vec![b'x'; SEGMENT_SIZE * 3];
     s.put_content(&big).unwrap();
     let count = |d: &std::path::Path| walkdir(d.join("blobs")).len();
@@ -283,4 +288,74 @@ fn a_tampered_leaf_on_disk_fails_its_proof() {
         !verify_inclusion(&after.leaf.leaf_id(), &proof, &head),
         "a tampered leaf must not prove under the old head"
     );
+}
+
+/// Content is not written to disk unless asked for.
+///
+/// The segments were write-only: nothing reconstructed content from them,
+/// because nothing recorded a revision's segment order. Meanwhile a fixed 1 KiB
+/// boundary means an edit near the top of a document makes every later segment
+/// new, so a revision pass cost a full copy of the manuscript each time.
+#[test]
+fn content_is_not_stored_by_default() {
+    let (dir, s) = store();
+    assert!(!s.keeps_content());
+
+    let commit = s.put_content(&vec![b'a'; 8 * 1024]).unwrap();
+
+    assert_eq!(
+        commit,
+        daon_provenance_core::content_commit(&vec![b'a'; 8 * 1024]),
+        "the commitment is unchanged -- only the storage is gone"
+    );
+    assert!(
+        !dir.path().join("blobs").exists(),
+        "no blobs directory is even created"
+    );
+}
+
+/// A chain stays cheap regardless of how much is written.
+#[test]
+fn a_long_chain_costs_only_its_leaves() {
+    let (dir, s) = store();
+    let signer = TestSigner::new(9);
+
+    // Edits at the *top*, which is the pattern that defeats segment dedup.
+    let mut text = vec![b'a'; 64 * 1024];
+    let mut entity = None;
+    for i in 0..50 {
+        text.insert(0, b'x');
+        let (e, _) = s
+            .append(entity.as_ref(), &text, &[obs(5)], beacon(), &signer, i)
+            .unwrap();
+        entity = Some(e);
+    }
+
+    let bytes: u64 = walk(dir.path())
+        .iter()
+        .filter_map(|p| std::fs::metadata(p).ok())
+        .map(|m| m.len())
+        .sum();
+
+    // 50 revisions of a 64 KB document. Storing segments would have cost
+    // megabytes; leaves and signatures cost 282 bytes each.
+    assert!(
+        bytes < 32 * 1024,
+        "50 revisions should cost well under 32 KB, cost {bytes} bytes"
+    );
+}
+
+fn walk(p: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(rd) = std::fs::read_dir(p) {
+        for e in rd.flatten() {
+            let path = e.path();
+            if path.is_dir() {
+                out.extend(walk(&path));
+            } else {
+                out.push(path);
+            }
+        }
+    }
+    out
 }

--- a/provenance/agentd/Cargo.toml
+++ b/provenance/agentd/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 daon-provenance-core.workspace = true
 daon-provenance-agent = { workspace = true, features = ["keychain"] }
 daon-provenance-witness.workspace = true
+daon-provenance-net.workspace = true
 # Hand-rolling a JSON parser is the one place in this project where doing it
 # ourselves would be reckless rather than principled: the input is
 # attacker-shaped and the failure modes are subtle. HTTP is different -- see

--- a/provenance/agentd/src/api.rs
+++ b/provenance/agentd/src/api.rs
@@ -18,6 +18,7 @@ use daon_provenance_agent::witness::WitnessLog;
 use daon_provenance_agent::{Signer, Store};
 use daon_provenance_core::{Beacon, BeaconChain, Hash, Ingress, Observation};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 use crate::http::{error_body, Request};
 
@@ -64,7 +65,7 @@ pub struct Agent {
 
 struct Inner {
     store: Store,
-    witness: WitnessLog,
+    witness: Arc<WitnessLog>,
     signer: Box<dyn Signer + Send>,
     limits: Limits,
     sessions: HashMap<String, Live>,
@@ -80,7 +81,7 @@ struct Live {
 impl Agent {
     pub fn new(
         store: Store,
-        witness: WitnessLog,
+        witness: Arc<WitnessLog>,
         signer: Box<dyn Signer + Send>,
         limits: Limits,
     ) -> Self {

--- a/provenance/agentd/src/lib.rs
+++ b/provenance/agentd/src/lib.rs
@@ -8,5 +8,6 @@
 pub mod api;
 pub mod http;
 pub mod server;
+pub mod witness_loop;
 
 pub use api::{Agent, Reply};

--- a/provenance/agentd/src/main.rs
+++ b/provenance/agentd/src/main.rs
@@ -30,6 +30,7 @@ use daon_provenance_agent::keystore;
 use daon_provenance_agent::policy::Limits;
 use daon_provenance_agent::witness::WitnessLog;
 use daon_provenance_agent::Store;
+use daon_provenance_witness::batch::BatchPolicy;
 
 use daon_provenance_agentd::{api::Agent, server};
 
@@ -47,12 +48,19 @@ struct Args {
     store: PathBuf,
     socket: PathBuf,
     identity: String,
+    /// Whether to reach OpenTimestamps at all.
+    ///
+    /// On by default, because an agent that does not witness produces leaves
+    /// that prove nothing about time. The flag exists for tests and for running
+    /// offline deliberately -- never as a default anyone drifts into.
+    witness: bool,
 }
 
 fn parse_args() -> Result<Args, String> {
     let mut store = None;
     let mut socket = None;
     let mut identity = "default".to_string();
+    let mut witness = true;
 
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
@@ -60,6 +68,7 @@ fn parse_args() -> Result<Args, String> {
             "--store" => store = Some(PathBuf::from(need(&mut args, "--store")?)),
             "--socket" => socket = Some(PathBuf::from(need(&mut args, "--socket")?)),
             "--identity" => identity = need(&mut args, "--identity")?,
+            "--no-witness" => witness = false,
             "-h" | "--help" => {
                 println!(
                     "daon-provenance-agentd --store PATH [--socket PATH] [--identity NAME]\n\
@@ -67,6 +76,7 @@ fn parse_args() -> Result<Args, String> {
                        --store     where leaves, blobs and witness state live (required)\n\
                        --socket    socket path (default: <store>/agent.sock)\n\
                        --identity  which keychain identity to sign with (default: default)\n\
+                       --no-witness  do not reach OpenTimestamps; heads queue and never anchor\n\
                      \n\
                      There is deliberately no --port. See the module docs."
                 );
@@ -82,6 +92,7 @@ fn parse_args() -> Result<Args, String> {
         store,
         socket,
         identity,
+        witness,
     })
 }
 
@@ -93,7 +104,9 @@ fn run() -> Result<(), String> {
     let args = parse_args()?;
 
     let store = Store::open(&args.store).map_err(|e| format!("opening store: {e}"))?;
-    let witness = WitnessLog::open(&args.store).map_err(|e| format!("witness state: {e}"))?;
+    let witness = std::sync::Arc::new(
+        WitnessLog::open(&args.store).map_err(|e| format!("witness state: {e}"))?,
+    );
 
     // Load, or create on first run. Creating returns the recovery secret exactly
     // once, and this is the only moment it can be shown to anyone.
@@ -118,10 +131,34 @@ fn run() -> Result<(), String> {
 
     let agent = Arc::new(Agent::new(
         store,
-        witness,
+        Arc::clone(&witness),
         Box::new(signer),
         Limits::default(),
     ));
+
+    // Start witnessing. Without this the agent queues heads and anchors nothing,
+    // which is a chain that proves sequence and not time -- and time is the
+    // whole claim. It runs on its own thread because the socket loop blocks.
+    if args.witness {
+        let http = Arc::new(daon_provenance_net::UreqHttp::new());
+        let calendars: Vec<String> = daon_provenance_net::calendar::PUBLIC_CALENDARS
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        eprintln!("witnessing via {} calendars", calendars.len());
+        let w = Arc::clone(&witness);
+        std::thread::spawn(move || {
+            daon_provenance_agentd::witness_loop::run_forever(
+                w,
+                http,
+                calendars,
+                BatchPolicy::default(),
+                now_ms,
+            )
+        });
+    } else {
+        eprintln!("witnessing disabled (--no-witness): heads will queue and never anchor");
+    }
 
     let listener = server::bind(&args.socket)?;
     eprintln!("listening on {}", args.socket.display());

--- a/provenance/agentd/src/witness_loop.rs
+++ b/provenance/agentd/src/witness_loop.rs
@@ -1,0 +1,173 @@
+//! The loop that actually witnesses heads.
+//!
+//! Everything else in this workspace was, until this existed, machinery nobody
+//! wound up. `WitnessLog` could queue heads, `Batch` could seal them, the
+//! calendar client could submit — and no code called any of it, so heads
+//! accumulated on disk and were never anchored. A chain in that state proves
+//! *sequence* and not *time*, and time is the entire claim.
+//!
+//! # Three things on a timer
+//!
+//! | Step | When | Why not sooner |
+//! | --- | --- | --- |
+//! | **Submit** | policy says so | witnesses are a shared resource; see `batch.rs` |
+//! | **Upgrade** | every tick | Bitcoin confirmation takes hours, so this mostly does nothing |
+//! | **Resolve** | after an upgrade | a head is pending until its batch is genuinely anchored |
+//!
+//! The upgrade step is the one that gets forgotten. A freshly submitted proof
+//! parses cleanly, looks complete, and carries no Bitcoin attestation. Without
+//! something coming back for it, every head stays unwitnessed forever while the
+//! files on disk look fine.
+//!
+//! # Failure is normal and must not be fatal
+//!
+//! Calendars go down. Networks drop. A tick that fails changes nothing on disk
+//! except leaving work queued for the next one, because the alternative — an
+//! agent that stops witnessing because a server was briefly unreachable — is
+//! worse than one that retries quietly.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use daon_provenance_agent::witness::WitnessLog;
+use daon_provenance_core::Hash;
+use daon_provenance_net::calendar::{submit_to_all, Calendar, CalendarError};
+use daon_provenance_net::Http;
+use daon_provenance_witness::attest::needs_upgrade;
+use daon_provenance_witness::batch::BatchPolicy;
+use daon_provenance_witness::ots::DetachedTimestamp;
+
+/// How often the loop wakes.
+///
+/// Not how often it submits — [`BatchPolicy`] decides that, and its floor is
+/// ten minutes. Waking more often than submitting is deliberate: the upgrade
+/// step needs to run on its own schedule, and an agent that only checked when
+/// it had something to send would never collect the proof for what it already
+/// sent.
+pub const TICK: Duration = Duration::from_secs(60);
+
+/// What one tick did. Returned rather than logged so a caller can decide how
+/// loud to be, and so tests can assert on it.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct TickOutcome {
+    /// Heads sealed into a batch and sent to at least one calendar.
+    pub submitted: usize,
+    /// Batches whose proof now carries a Bitcoin attestation.
+    pub upgraded: usize,
+    /// Heads that stopped being pending because their batch is anchored.
+    pub resolved: usize,
+    /// Calendars that could not be reached. Expected, not fatal.
+    pub unreachable: usize,
+}
+
+/// Run one tick.
+///
+/// Split out from the loop so it can be driven by a test with a canned
+/// transport, and so a caller that wants to force a submission does not have to
+/// wait out a timer.
+pub fn tick<H: Http>(
+    witness: &WitnessLog,
+    http: &H,
+    calendars: &[&str],
+    policy: &BatchPolicy,
+    now_ms: i64,
+) -> TickOutcome {
+    let mut out = TickOutcome::default();
+
+    // ── 1. Submit, if policy allows ──────────────────────────────────────
+    if witness.should_submit(policy, now_ms).unwrap_or(false) {
+        if let Ok(Some(sealed)) = witness.seal() {
+            let (proofs, failures) = submit_to_all(http, &sealed.root, calendars);
+            out.unreachable += failures.len();
+
+            // One proof is enough to establish a time. Recording only on
+            // success means a total failure leaves the heads queued, which is
+            // what the next tick is for.
+            if let Some((_, proof)) = proofs.first() {
+                if let Ok(bytes) = proof.encode() {
+                    if witness.record(&sealed, &bytes, now_ms).is_ok() {
+                        out.submitted = sealed.members.len();
+                    }
+                }
+            }
+        }
+    }
+
+    // ── 2. Upgrade anything still pending ────────────────────────────────
+    //
+    // Runs every tick regardless of the submission floor: this collects proofs
+    // for work already sent, and rate-limiting it would only delay anchoring
+    // that has already happened.
+    for root in witness.batches().unwrap_or_default() {
+        let stored = match witness.proof(&root) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        let parsed = match DetachedTimestamp::decode(&stored) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        // Already anchored -- nothing to fetch, and refetching would spend a
+        // request to learn what is already on disk.
+        if !needs_upgrade(&parsed).unwrap_or(true) {
+            resolve_batch(witness, &root, &mut out);
+            continue;
+        }
+
+        for url in calendars {
+            match Calendar::new(*url, http).upgrade(&root) {
+                Ok(upgraded) => {
+                    if let Ok(bytes) = upgraded.encode() {
+                        if witness.upgrade(&root, &bytes).is_ok() {
+                            out.upgraded += 1;
+                            resolve_batch(witness, &root, &mut out);
+                        }
+                    }
+                    break;
+                }
+                // The ordinary answer for hours after submitting. Not worth
+                // counting as a failure or reporting to anyone.
+                Err(CalendarError::NotReadyYet) => {}
+                Err(_) => out.unreachable += 1,
+            }
+        }
+    }
+
+    out
+}
+
+/// Stop tracking a batch's heads as pending, now that its proof is anchored.
+fn resolve_batch(witness: &WitnessLog, root: &Hash, out: &mut TickOutcome) {
+    for member in witness.members(root).unwrap_or_default() {
+        if witness.resolve(&member.head).is_ok() {
+            out.resolved += 1;
+        }
+    }
+}
+
+/// Run forever, on [`TICK`].
+///
+/// Spawned by the daemon at startup. Sleeps rather than spinning, and never
+/// returns — a witness loop that exits on error would leave an agent that looks
+/// healthy and silently stops anchoring, which is the failure this whole module
+/// exists to prevent.
+pub fn run_forever<H: Http + Send + Sync + 'static>(
+    witness: Arc<WitnessLog>,
+    http: Arc<H>,
+    calendars: Vec<String>,
+    policy: BatchPolicy,
+    now: fn() -> i64,
+) {
+    loop {
+        let refs: Vec<&str> = calendars.iter().map(String::as_str).collect();
+        let outcome = tick(&witness, http.as_ref(), &refs, &policy, now());
+
+        if outcome != TickOutcome::default() {
+            eprintln!(
+                "witness: submitted {} · upgraded {} · resolved {} · unreachable {}",
+                outcome.submitted, outcome.upgraded, outcome.resolved, outcome.unreachable
+            );
+        }
+        std::thread::sleep(TICK);
+    }
+}

--- a/provenance/agentd/tests/api.rs
+++ b/provenance/agentd/tests/api.rs
@@ -31,7 +31,7 @@ impl Signer for TestSigner {
 fn agent() -> (TempDir, Agent) {
     let dir = TempDir::new().unwrap();
     let store = Store::open(dir.path()).unwrap();
-    let witness = WitnessLog::open(dir.path()).unwrap();
+    let witness = std::sync::Arc::new(WitnessLog::open(dir.path()).unwrap());
     (
         dir,
         Agent::new(store, witness, Box::new(TestSigner), Limits::default()),

--- a/provenance/agentd/tests/socket.rs
+++ b/provenance/agentd/tests/socket.rs
@@ -34,7 +34,7 @@ fn running() -> (TempDir, std::path::PathBuf) {
     let sock = dir.path().join("agent.sock");
 
     let store = Store::open(dir.path()).unwrap();
-    let witness = WitnessLog::open(dir.path()).unwrap();
+    let witness = std::sync::Arc::new(WitnessLog::open(dir.path()).unwrap());
     let agent = Arc::new(Agent::new(
         store,
         witness,

--- a/provenance/agentd/tests/witness_loop.rs
+++ b/provenance/agentd/tests/witness_loop.rs
@@ -1,0 +1,243 @@
+//! The witness loop, driven against a canned transport.
+//!
+//! No test here reaches the network. `Http` is the seam precisely so the loop's
+//! behaviour — including what it does when a calendar is down — is checkable
+//! offline.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use daon_provenance_agent::witness::WitnessLog;
+use daon_provenance_agentd::witness_loop::{tick, TickOutcome};
+use daon_provenance_core::{merkle_root, Hash};
+use daon_provenance_net::http::{Http, HttpError};
+use daon_provenance_witness::batch::BatchPolicy;
+use daon_provenance_witness::ots::{Attestation, DetachedTimestamp, Op, Timestamp};
+use tempfile::TempDir;
+
+/// A transport that answers from a script and records what it was asked.
+struct Canned {
+    posts: RefCell<Vec<String>>,
+    gets: RefCell<Vec<String>>,
+    post_body: Option<Vec<u8>>,
+    get_body: Option<Vec<u8>>,
+}
+
+impl Canned {
+    fn new() -> Self {
+        Canned {
+            posts: RefCell::new(Vec::new()),
+            gets: RefCell::new(Vec::new()),
+            post_body: None,
+            get_body: None,
+        }
+    }
+}
+
+impl Http for Canned {
+    fn post(&self, url: &str, _body: &[u8], _ct: &str) -> Result<Vec<u8>, HttpError> {
+        self.posts.borrow_mut().push(url.to_string());
+        self.post_body
+            .clone()
+            .ok_or_else(|| HttpError::Transport("calendar unreachable".into()))
+    }
+    fn get(&self, url: &str) -> Result<Vec<u8>, HttpError> {
+        self.gets.borrow_mut().push(url.to_string());
+        self.get_body.clone().ok_or(HttpError::Status {
+            code: 404,
+            body: String::new(),
+        })
+    }
+}
+
+/// A calendar's answer: a fragment, not a whole `.ots` file.
+fn fragment(attestation: Attestation) -> Vec<u8> {
+    let proof = DetachedTimestamp {
+        file_hash_op: Op::Sha256,
+        digest: vec![0u8; 32],
+        timestamp: Timestamp {
+            attestations: vec![attestation],
+            ops: vec![],
+        },
+    };
+    let whole = proof.encode().unwrap();
+    // Strip the magic, version, hash op and digest to leave the tree alone.
+    whole[daon_provenance_witness::ots::MAGIC.len() + 1 + 1 + 32..].to_vec()
+}
+
+fn pending_fragment() -> Vec<u8> {
+    fragment(Attestation::Pending {
+        uri: b"https://alice.btc.calendar.opentimestamps.org".to_vec(),
+    })
+}
+
+fn anchored_fragment() -> Vec<u8> {
+    fragment(Attestation::Bitcoin { height: 810_000 })
+}
+
+fn log_with(heads: &[Hash], now: i64) -> (TempDir, WitnessLog) {
+    let dir = TempDir::new().unwrap();
+    let log = WitnessLog::open(dir.path()).unwrap();
+    for h in heads {
+        log.queue(h, now).unwrap();
+    }
+    (dir, log)
+}
+
+fn eager() -> BatchPolicy {
+    BatchPolicy {
+        max_heads: 1,
+        max_wait_ms: 0,
+        min_interval_ms: 0,
+    }
+}
+
+#[test]
+fn a_tick_submits_pending_heads() {
+    let (_d, log) = log_with(&[[1u8; 32], [2u8; 32]], 1_000);
+    let mut http = Canned::new();
+    http.post_body = Some(pending_fragment());
+
+    let out = tick(&log, &http, &["https://cal.example"], &eager(), 2_000);
+
+    assert_eq!(out.submitted, 2, "both queued heads went in one batch");
+    assert_eq!(
+        http.posts.borrow().len(),
+        1,
+        "one submission, not one per head"
+    );
+    assert!(http.posts.borrow()[0].ends_with("/digest"));
+}
+
+/// The step that gets forgotten: a submitted proof is pending and proves nothing
+/// until something comes back for it.
+#[test]
+fn a_pending_head_is_not_resolved_until_the_proof_is_anchored() {
+    let (_d, log) = log_with(&[[3u8; 32]], 1_000);
+    let mut http = Canned::new();
+    http.post_body = Some(pending_fragment());
+
+    let out = tick(&log, &http, &["https://cal.example"], &eager(), 2_000);
+    assert_eq!(out.submitted, 1);
+    assert_eq!(out.resolved, 0, "pending is not witnessed");
+    assert_eq!(log.pending().unwrap().len(), 1, "still queued");
+}
+
+#[test]
+fn an_upgraded_proof_resolves_its_heads() {
+    let (_d, log) = log_with(&[[4u8; 32]], 1_000);
+    let mut http = Canned::new();
+    http.post_body = Some(pending_fragment());
+    tick(&log, &http, &["https://cal.example"], &eager(), 2_000);
+
+    // Bitcoin has now confirmed it.
+    http.get_body = Some(anchored_fragment());
+    let out = tick(&log, &http, &["https://cal.example"], &eager(), 3_000);
+
+    assert_eq!(out.upgraded, 1);
+    assert_eq!(out.resolved, 1);
+    assert!(log.pending().unwrap().is_empty(), "head is witnessed");
+}
+
+/// A calendar being down must leave work queued rather than losing it.
+#[test]
+fn an_unreachable_calendar_loses_nothing() {
+    let (_d, log) = log_with(&[[5u8; 32]], 1_000);
+    let http = Canned::new(); // every request fails
+
+    let out = tick(&log, &http, &["https://down.example"], &eager(), 2_000);
+
+    assert_eq!(out.submitted, 0);
+    assert!(out.unreachable >= 1);
+    assert_eq!(log.pending().unwrap().len(), 1, "the head is still queued");
+}
+
+/// The batching floor is the protection for a shared resource, so the loop must
+/// respect it rather than submitting on every tick.
+#[test]
+fn the_rate_floor_is_respected() {
+    let (_d, log) = log_with(&[[6u8; 32]], 0);
+    let mut http = Canned::new();
+    http.post_body = Some(pending_fragment());
+    let policy = BatchPolicy {
+        max_heads: 1,
+        max_wait_ms: 0,
+        min_interval_ms: 600_000,
+    };
+
+    assert_eq!(
+        tick(&log, &http, &["https://cal.example"], &policy, 1_000).submitted,
+        1
+    );
+    // Immediately after, inside the floor.
+    let (_d2, log2) = log_with(&[[7u8; 32]], 0);
+    log2.queue(&[8u8; 32], 0).unwrap();
+    tick(&log2, &http, &["https://cal.example"], &policy, 1_000);
+    let out = tick(&log2, &http, &["https://cal.example"], &policy, 2_000);
+    assert_eq!(out.submitted, 0, "must not submit again inside the floor");
+}
+
+#[test]
+fn nothing_queued_means_nothing_happens() {
+    let (_d, log) = log_with(&[], 1_000);
+    let http = Canned::new();
+    assert_eq!(
+        tick(&log, &http, &["https://cal.example"], &eager(), 2_000),
+        TickOutcome::default()
+    );
+    assert!(http.posts.borrow().is_empty(), "no request without work");
+}
+
+/// One anchor covering many heads is the whole point of batching.
+#[test]
+fn one_submission_covers_every_queued_head() {
+    let heads: Vec<Hash> = (0..16u8).map(|i| [i; 32]).collect();
+    let (_d, log) = log_with(&heads, 1_000);
+    let mut http = Canned::new();
+    http.post_body = Some(pending_fragment());
+    http.get_body = Some(anchored_fragment());
+
+    tick(&log, &http, &["https://cal.example"], &eager(), 2_000);
+    let out = tick(&log, &http, &["https://cal.example"], &eager(), 3_000);
+
+    assert_eq!(out.resolved, 16, "sixteen heads, one anchor");
+    assert!(log.pending().unwrap().is_empty());
+
+    // And the batch root really is the Merkle root over those heads.
+    let batches = log.batches().unwrap();
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0], merkle_root(&heads));
+}
+
+#[test]
+fn a_second_calendar_is_tried_when_the_first_fails() {
+    let (_d, log) = log_with(&[[9u8; 32]], 1_000);
+    let mut http = Canned::new();
+    http.post_body = Some(pending_fragment());
+
+    tick(
+        &log,
+        &http,
+        &["https://a.example", "https://b.example"],
+        &eager(),
+        2_000,
+    );
+    let posts = http.posts.borrow();
+    assert_eq!(posts.len(), 2, "submitted to both, for redundancy");
+}
+
+/// Sanity: the loop must never send content anywhere. Only a digest.
+#[test]
+fn only_a_digest_leaves_the_machine() {
+    let (_d, log) = log_with(&[[10u8; 32]], 1_000);
+    let mut http = Canned::new();
+    http.post_body = Some(pending_fragment());
+
+    tick(&log, &http, &["https://cal.example"], &eager(), 2_000);
+
+    let seen: HashMap<&str, usize> = HashMap::new();
+    let _ = seen;
+    for url in http.posts.borrow().iter() {
+        assert!(url.ends_with("/digest"), "unexpected endpoint: {url}");
+    }
+}

--- a/provenance/net/Cargo.toml
+++ b/provenance/net/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "daon-provenance-net"
+version = "0.0.0"          # not published; the wire format is not frozen yet
+description = "The only crate in this workspace that talks to the network"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+daon-provenance-core.workspace = true
+daon-provenance-witness.workspace = true
+# Blocking, and rustls rather than the system TLS stack. The daemon is
+# synchronous and thread-per-connection; an async runtime it never drives would
+# be dead weight, and a pure-Rust TLS stack keeps the build free of system
+# libraries on every platform.
+ureq = { version = "2", default-features = false, features = ["tls"] }
+
+[dev-dependencies]
+hex.workspace = true

--- a/provenance/net/src/blocks.rs
+++ b/provenance/net/src/blocks.rs
@@ -1,0 +1,115 @@
+//! Resolving a Bitcoin block height to the header fields a proof needs.
+//!
+//! [`daon_provenance_witness::BlockSource`] deliberately has no implementation
+//! in the witness crate, because **whoever answers these questions decides what
+//! the whole proof rests on.** A full node answers from consensus; a header
+//! chain answers from proof-of-work; a public API answers because it says so.
+//! Burying that choice in a library would hide the most consequential assumption
+//! in the system.
+//!
+//! So this lives here, in the crate whose entire job is to be the visible place
+//! where trust leaves the machine, and it is one implementation among several a
+//! caller might reasonably prefer.
+//!
+//! # What this one trusts
+//!
+//! An HTTP API. That is weaker than a node and it is stated rather than
+//! implied: a service that lies about a merkle root can make a forged proof
+//! verify. It is a reasonable default for a creator who is not going to run
+//! Bitcoin Core, and it should never be described as trustless.
+
+use daon_provenance_witness::{BlockHeader, BlockSource};
+
+use crate::http::Http;
+
+/// A [`BlockSource`] backed by an Esplora-compatible HTTP API.
+///
+/// Esplora is what Blockstream and mempool.space run, and its shape is
+/// widely reimplemented, so pointing this at a self-hosted instance is a
+/// one-line change rather than a different implementation.
+pub struct HttpBlockSource<'a, H: Http> {
+    base_url: String,
+    http: &'a H,
+}
+
+impl<'a, H: Http> HttpBlockSource<'a, H> {
+    /// Point at an Esplora-compatible API.
+    ///
+    /// `https://blockstream.info/api` and `https://mempool.space/api` both
+    /// work. Prefer your own.
+    pub fn new(base_url: impl Into<String>, http: &'a H) -> Self {
+        HttpBlockSource {
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            http,
+        }
+    }
+
+    fn fetch(&self, height: u64) -> Option<BlockHeader> {
+        // Two calls, because Esplora addresses blocks by hash rather than
+        // height: the first resolves the height, the second reads the header.
+        let hash = String::from_utf8(
+            self.http
+                .get(&format!("{}/block-height/{height}", self.base_url))
+                .ok()?,
+        )
+        .ok()?;
+        let hash = hash.trim();
+        if hash.len() != 64 || !hash.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return None;
+        }
+
+        let body = self
+            .http
+            .get(&format!("{}/block/{hash}", self.base_url))
+            .ok()?;
+        let text = String::from_utf8(body).ok()?;
+
+        // A minimal field scrape rather than a JSON dependency. Two numbers and
+        // a hex string are not worth a parser, and the fields are fixed shapes:
+        // `"merkle_root":"<64 hex>"` and `"timestamp":<digits>`.
+        let merkle_root_hex = scrape_string(&text, "merkle_root")?;
+        let time_secs: u32 = scrape_number(&text, "timestamp")?.try_into().ok()?;
+
+        // Esplora reports the merkle root in display order, which is the
+        // reverse of the internal byte order a timestamp proof computes. Getting
+        // this backwards makes every proof fail to verify against a block that
+        // does commit to it.
+        let mut root = [0u8; 32];
+        for (i, byte) in root.iter_mut().enumerate() {
+            let j = 31 - i;
+            *byte = u8::from_str_radix(merkle_root_hex.get(j * 2..j * 2 + 2)?, 16).ok()?;
+        }
+
+        Some(BlockHeader {
+            merkle_root: root,
+            time_secs,
+        })
+    }
+}
+
+impl<H: Http> BlockSource for HttpBlockSource<'_, H> {
+    fn header(&self, height: u64) -> Option<BlockHeader> {
+        self.fetch(height)
+    }
+}
+
+/// Pull `"key":"value"` out of a JSON object without parsing it.
+fn scrape_string<'t>(text: &'t str, key: &str) -> Option<&'t str> {
+    let at = text.find(&format!("\"{key}\""))?;
+    let rest = &text[at + key.len() + 2..];
+    let open = rest.find('"')? + 1;
+    let close = rest[open..].find('"')? + open;
+    Some(&rest[open..close])
+}
+
+/// Pull `"key":123` out of a JSON object without parsing it.
+fn scrape_number(text: &str, key: &str) -> Option<u64> {
+    let at = text.find(&format!("\"{key}\""))?;
+    let rest = &text[at + key.len() + 2..];
+    let start = rest.find(|c: char| c.is_ascii_digit())?;
+    let end = rest[start..]
+        .find(|c: char| !c.is_ascii_digit())
+        .map(|e| e + start)
+        .unwrap_or(rest.len());
+    rest[start..end].parse().ok()
+}

--- a/provenance/net/src/calendar.rs
+++ b/provenance/net/src/calendar.rs
@@ -1,0 +1,178 @@
+//! Submitting a digest to an OpenTimestamps calendar, and collecting the proof.
+//!
+//! A calendar is a free public aggregator. You give it 32 bytes; it merges them
+//! with everyone else's into a Merkle tree and periodically writes that tree's
+//! root into a Bitcoin transaction. One fee covers everybody who submitted in
+//! that interval, which is why timestamping is affordable at all.
+//!
+//! Our batching sits on top of theirs: we merge a creator's heads into one root,
+//! the calendar merges that root with the world's.
+//!
+//! # The two-step shape, which is easy to get wrong
+//!
+//! Submission returns immediately with a **pending** proof — a receipt saying a
+//! calendar has the digest, carrying no Bitcoin attestation. It parses cleanly
+//! and looks finished and proves nothing about time.
+//!
+//! The real proof exists only after a Bitcoin transaction confirms, which takes
+//! hours. Something has to come back and fetch it. Until it does, the head is
+//! not witnessed, whatever the file on disk looks like.
+//!
+//! # What a calendar learns
+//!
+//! A 32-byte digest and the fact that somebody timestamped something. Not what,
+//! not whose, not how large, not how many heads are inside it. Submitting to
+//! several is normal and is what the public pool does.
+
+use daon_provenance_core::Hash;
+use daon_provenance_witness::ots::{Attestation, DetachedTimestamp};
+
+use crate::http::{Http, HttpError};
+
+/// The public calendars operated by the OpenTimestamps project.
+///
+/// Submitting to more than one is deliberate redundancy: any single calendar
+/// may vanish, and a proof from a calendar that no longer exists is still valid
+/// — but only if it was upgraded before it went. More submissions, more chances
+/// the upgrade succeeds.
+pub const PUBLIC_CALENDARS: &[&str] = &[
+    "https://alice.btc.calendar.opentimestamps.org",
+    "https://bob.btc.calendar.opentimestamps.org",
+    "https://finney.calendar.eternitywall.com",
+];
+
+/// Why a calendar interaction failed.
+#[derive(Debug)]
+pub enum CalendarError {
+    /// The request did not complete.
+    Http(HttpError),
+    /// The calendar answered with something that is not a timestamp.
+    Malformed(String),
+    /// Asked for an upgrade that is not ready. Expected, and not a failure —
+    /// Bitcoin confirmation takes hours.
+    NotReadyYet,
+}
+
+impl std::fmt::Display for CalendarError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CalendarError::Http(e) => write!(f, "{e}"),
+            CalendarError::Malformed(m) => write!(f, "calendar returned {m}"),
+            CalendarError::NotReadyYet => {
+                write!(f, "not yet anchored; try again after the next block")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CalendarError {}
+
+impl From<HttpError> for CalendarError {
+    fn from(e: HttpError) -> Self {
+        CalendarError::Http(e)
+    }
+}
+
+/// A client for one calendar.
+pub struct Calendar<'a, H: Http> {
+    base_url: String,
+    http: &'a H,
+}
+
+impl<'a, H: Http> Calendar<'a, H> {
+    /// Point a client at a calendar. The URL is used as given, with no
+    /// discovery and no redirects followed to somewhere else.
+    pub fn new(base_url: impl Into<String>, http: &'a H) -> Self {
+        Calendar {
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            http,
+        }
+    }
+
+    /// Submit a digest. Returns the **pending** proof.
+    ///
+    /// The calendar's response is a timestamp *fragment*: the operations
+    /// leading from your digest into its aggregation tree, ending in a pending
+    /// attestation. It is not a `.ots` file — that framing is added here, so
+    /// what gets stored is a complete detached proof rather than a fragment
+    /// only this code knows how to read.
+    pub fn submit(&self, digest: &Hash) -> Result<DetachedTimestamp, CalendarError> {
+        let body = self.http.post(
+            &format!("{}/digest", self.base_url),
+            digest,
+            "application/octet-stream",
+        )?;
+
+        let timestamp = daon_provenance_witness::ots::parse_fragment(&body)
+            .map_err(|e| CalendarError::Malformed(format!("{e:?}")))?;
+
+        Ok(DetachedTimestamp {
+            file_hash_op: daon_provenance_witness::ots::Op::Sha256,
+            digest: digest.to_vec(),
+            timestamp,
+        })
+    }
+
+    /// Fetch the upgraded proof for a digest, once Bitcoin has confirmed it.
+    ///
+    /// [`CalendarError::NotReadyYet`] is the ordinary answer for hours after
+    /// submission and callers should treat it as such rather than as an error
+    /// worth reporting to anyone.
+    pub fn upgrade(&self, digest: &Hash) -> Result<DetachedTimestamp, CalendarError> {
+        let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
+        let body = match self.http.get(&format!("{}/timestamp/{hex}", self.base_url)) {
+            Ok(b) => b,
+            // A calendar answers 404 while a digest is known but not yet
+            // anchored. That is "come back later", not "no such thing".
+            Err(HttpError::Status { code: 404, .. }) => return Err(CalendarError::NotReadyYet),
+            Err(e) => return Err(e.into()),
+        };
+
+        let timestamp = daon_provenance_witness::ots::parse_fragment(&body)
+            .map_err(|e| CalendarError::Malformed(format!("{e:?}")))?;
+
+        let proof = DetachedTimestamp {
+            file_hash_op: daon_provenance_witness::ots::Op::Sha256,
+            digest: digest.to_vec(),
+            timestamp,
+        };
+
+        // A calendar can answer with a still-pending fragment. Returning it as
+        // an upgrade would let a caller overwrite a good proof with a worthless
+        // one, so it is refused here rather than trusted to be checked later.
+        let has_bitcoin = proof
+            .attestations()
+            .map_err(|e| CalendarError::Malformed(format!("{e:?}")))?
+            .iter()
+            .any(|(a, _)| matches!(a, Attestation::Bitcoin { .. }));
+
+        if !has_bitcoin {
+            return Err(CalendarError::NotReadyYet);
+        }
+        Ok(proof)
+    }
+}
+
+/// What a round of submissions produced: the proofs, and who could not be
+/// reached. Named because a bare tuple of two vectors of tuples is unreadable.
+pub type SubmitResults = (
+    Vec<(String, DetachedTimestamp)>,
+    Vec<(String, CalendarError)>,
+);
+
+/// Submit to several calendars, keeping every proof that came back.
+///
+/// Failures are returned alongside successes rather than aborting: one calendar
+/// being down is not a reason to discard a proof another one gave you, and a
+/// single surviving proof is enough to establish a time.
+pub fn submit_to_all<H: Http>(http: &H, digest: &Hash, calendars: &[&str]) -> SubmitResults {
+    let mut proofs = Vec::new();
+    let mut failures = Vec::new();
+    for url in calendars {
+        match Calendar::new(*url, http).submit(digest) {
+            Ok(p) => proofs.push((url.to_string(), p)),
+            Err(e) => failures.push((url.to_string(), e)),
+        }
+    }
+    (proofs, failures)
+}

--- a/provenance/net/src/http.rs
+++ b/provenance/net/src/http.rs
@@ -1,0 +1,126 @@
+//! The seam between this crate and the network.
+//!
+//! Narrow on purpose. Two verbs, bytes in and bytes out, no headers a caller can
+//! set and no methods beyond what the two clients need. A wider interface would
+//! let future code make requests this crate's docs do not describe.
+
+use std::time::Duration;
+
+/// Why a request failed.
+#[derive(Debug)]
+pub enum HttpError {
+    /// The request never completed — DNS, connection, TLS, timeout.
+    Transport(String),
+    /// A response arrived with a status this client does not accept.
+    Status {
+        /// The status code returned.
+        code: u16,
+        /// Body text, truncated. Calendars explain refusals in prose.
+        body: String,
+    },
+    /// The response body could not be read.
+    Body(String),
+}
+
+impl std::fmt::Display for HttpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HttpError::Transport(e) => write!(f, "transport: {e}"),
+            HttpError::Status { code, body } => write!(f, "http {code}: {body}"),
+            HttpError::Body(e) => write!(f, "reading body: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for HttpError {}
+
+/// Everything this crate can do to the outside world.
+///
+/// Implemented once for real requests and substituted in tests, so nothing in
+/// this workspace reaches the network during a build or a test run.
+pub trait Http {
+    /// POST bytes, return the response body.
+    fn post(&self, url: &str, body: &[u8], content_type: &str) -> Result<Vec<u8>, HttpError>;
+    /// GET a URL, return the response body.
+    fn get(&self, url: &str) -> Result<Vec<u8>, HttpError>;
+}
+
+/// Response bodies larger than this are refused.
+///
+/// A calendar proof is a few hundred bytes and a block header is smaller. A
+/// remote server should not be able to make this process allocate without
+/// bound, and a body far outside the expected size is a sign something is wrong
+/// rather than something to parse.
+const MAX_RESPONSE: usize = 1024 * 1024;
+
+/// The real client.
+pub struct UreqHttp {
+    agent: ureq::Agent,
+}
+
+impl UreqHttp {
+    /// A client with sensible timeouts.
+    ///
+    /// Timeouts rather than none: a calendar that accepts a connection and then
+    /// stops talking would otherwise hang the witness loop indefinitely, and an
+    /// unwitnessed head is better than a stuck agent.
+    pub fn new() -> Self {
+        UreqHttp {
+            agent: ureq::AgentBuilder::new()
+                .timeout_connect(Duration::from_secs(10))
+                .timeout(Duration::from_secs(30))
+                .user_agent(concat!("daon-provenance/", env!("CARGO_PKG_VERSION")))
+                .build(),
+        }
+    }
+}
+
+impl Default for UreqHttp {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn read_capped(resp: ureq::Response) -> Result<Vec<u8>, HttpError> {
+    let mut buf = Vec::new();
+    resp.into_reader()
+        .take(MAX_RESPONSE as u64 + 1)
+        .read_to_end(&mut buf)
+        .map_err(|e| HttpError::Body(e.to_string()))?;
+    if buf.len() > MAX_RESPONSE {
+        return Err(HttpError::Body("response exceeds the size limit".into()));
+    }
+    Ok(buf)
+}
+
+use std::io::Read;
+
+fn convert(e: ureq::Error) -> HttpError {
+    match e {
+        ureq::Error::Status(code, resp) => {
+            let body = resp.into_string().unwrap_or_default();
+            HttpError::Status {
+                code,
+                body: body.chars().take(300).collect(),
+            }
+        }
+        other => HttpError::Transport(other.to_string()),
+    }
+}
+
+impl Http for UreqHttp {
+    fn post(&self, url: &str, body: &[u8], content_type: &str) -> Result<Vec<u8>, HttpError> {
+        let resp = self
+            .agent
+            .post(url)
+            .set("Content-Type", content_type)
+            .send_bytes(body)
+            .map_err(convert)?;
+        read_capped(resp)
+    }
+
+    fn get(&self, url: &str) -> Result<Vec<u8>, HttpError> {
+        let resp = self.agent.get(url).call().map_err(convert)?;
+        read_capped(resp)
+    }
+}

--- a/provenance/net/src/lib.rs
+++ b/provenance/net/src/lib.rs
@@ -1,0 +1,38 @@
+//! The only crate in this workspace that talks to the network.
+//!
+//! Everything else is deliberately offline: `core` hashes, `verify` checks,
+//! `witness` parses proofs, `agent` writes files. None of them can open a
+//! socket, and that is a structural fact rather than a convention — a reviewer
+//! confirms it by reading one `Cargo.toml`.
+//!
+//! This crate exists so the agent's egress is **enumerable**. Every outbound
+//! request it can make is in this file and the two beside it. If that stops
+//! being true, the property the design claims has quietly stopped being true
+//! too.
+//!
+//! # What may leave the machine
+//!
+//! | Destination | Sends | Never sends |
+//! | --- | --- | --- |
+//! | [`calendar`] | one 32-byte digest | content, keys, filenames, counts |
+//! | [`blocks`] | a block height | anything about the creator |
+//!
+//! A calendar learns a digest and the fact that somebody timestamped something.
+//! It cannot tell what, whose, or how large. That is the whole privacy story and
+//! it holds only while this crate stays small.
+//!
+//! # Everything is behind a trait
+//!
+//! [`Http`] is the seam. Tests substitute a canned transport, so no test in this
+//! workspace reaches the network — including the ones that check what a request
+//! looks like.
+
+#![deny(missing_docs)]
+
+pub mod blocks;
+pub mod calendar;
+pub mod http;
+
+pub use blocks::HttpBlockSource;
+pub use calendar::{Calendar, CalendarError};
+pub use http::{Http, HttpError, UreqHttp};

--- a/provenance/witness/src/ots.rs
+++ b/provenance/witness/src/ots.rs
@@ -386,6 +386,25 @@ impl<'a> Cursor<'a> {
     }
 }
 
+/// Parse a bare timestamp tree, without the `.ots` framing.
+///
+/// A calendar answers a submission with a **fragment**: the operations leading
+/// from your digest into its aggregation tree, and nothing else. No magic, no
+/// version, no digest — those belong to a detached proof file, and the calendar
+/// assumes you still have the digest you just sent it.
+///
+/// So this parses the part a calendar sends, and the caller adds the framing to
+/// produce a file anything can read. Storing the fragment as-is would leave a
+/// blob only this codebase knows how to interpret.
+pub fn parse_fragment(bytes: &[u8]) -> Result<Timestamp, Error> {
+    let mut c = Cursor::new(bytes);
+    let ts = c.timestamp()?;
+    if !c.is_empty() {
+        return Err(Error::TrailingBytes);
+    }
+    Ok(ts)
+}
+
 // ── encoding ──────────────────────────────────────────────────────────────
 
 fn put_varint(out: &mut Vec<u8>, mut v: u64) {


### PR DESCRIPTION
**Nothing in this workspace could open a socket.** Not restricted egress — none. No HTTP client, no TLS, no runtime:

```
reqwest / ureq / hyper / rustls / native-tls / tokio  →  absent
```

So every crate doc describing what the agent "sends" or "reaches" was describing an intention, and heads queued on disk forever while the files looked fine. **A chain in that state proves sequence and not time, and time is the whole claim.**

## `daon-provenance-net` — the only crate that talks to the network

Egress becomes *enumerable* rather than asserted: a reviewer confirms what can leave the machine by reading one `Cargo.toml` and three files. A calendar learns a 32-byte digest and that somebody timestamped something — not what, not whose, not how large, not how many heads are inside.

`Http` is the seam, deliberately narrow: two verbs, bytes in and bytes out, no caller-settable headers. **No test in this workspace reaches the network**, including the ones asserting what a request looks like.

## The calendar client — the two calls that were missing

`submit` returns a **pending** fragment: a receipt, parsing cleanly, carrying no Bitcoin attestation. `upgrade` fetches the real proof hours later once a transaction confirms.

`upgrade` refuses to return a still-pending fragment — handing one back would let a caller **overwrite a good proof with a worthless one**. Submission goes to several calendars and keeps every proof that returns: one being down is no reason to discard another's.

## `HttpBlockSource`

Lives in `net` rather than `witness` because **whoever answers "what's in block N" decides what the whole proof rests on**. It trusts an HTTP API, which is weaker than a node, and says so rather than implying trustlessness.

It also reverses the merkle root: Esplora reports display order, a timestamp proof computes internal order. Getting that backwards makes every proof fail against a block that *does* commit to it.

## The witness loop — the part that was entirely absent

Three things on a timer:

| Step | When | Why |
|---|---|---|
| Submit | policy allows | witnesses are a shared resource |
| Upgrade | **every tick** | collects proofs for work already sent; throttling only delays anchoring that already happened |
| Resolve | after upgrade | a head is pending until its batch is genuinely anchored |

A failed tick changes nothing except leaving work queued — an agent that stops witnessing over a brief outage is worse than one that retries quietly.

**Witnessing is on by default.** `--no-witness` opts out and says what that costs; anything else is a default someone drifts into.

## Tests

153, up from 126. The new ones drive the loop against canned responses: a submitted head is **not** resolved until its proof is anchored, an unreachable calendar loses nothing, the batching floor is respected, sixteen heads resolve under one anchor, and the only endpoint anything posts to is `/digest`.

## What is still missing

Two things, now honestly not load-bearing:

- **Reading content back out of the store** — segments are stored by hash with no manifest recording their order.
- **Binary and image registration** — text only.

A chain can now be written, batched, submitted, upgraded and verified end to end.