### PR TITLE
feat: close the circuit — answer the email, and verify the calendar for real

### DIFF
--- a/api-server/src/database/client.ts
+++ b/api-server/src/database/client.ts
@@ -325,17 +325,19 @@ export const db = {
       recovery_key?: string | null;
       status?: string;
       expires_at?: Date | null;
+      resolution_token?: string | null;
     }) {
       const result = await db.query(
         `INSERT INTO content_associations
            (content_hash, entity_id, head, asserted_by, author_key, recovery_key,
-            status, expires_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            status, expires_at, resolution_token)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
          RETURNING *`,
         [
           data.content_hash, data.entity_id, data.head, data.asserted_by,
           data.author_key ?? null, data.recovery_key ?? null,
           data.status ?? 'current', data.expires_at ?? null,
+          data.resolution_token ?? null,
         ]
       );
       return result.rows[0];
@@ -358,6 +360,17 @@ export const db = {
       return result.rows[0] ?? null;
     },
 
+    /** Find a pending association by its single-use token. */
+    async findByToken(token: string) {
+      const result = await db.query(
+        `SELECT * FROM content_associations
+          WHERE resolution_token = $1 AND status = 'pending'
+            AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)`,
+        [token]
+      );
+      return result.rows[0] ?? null;
+    },
+
     /**
      * Resolve a pending association.
      *
@@ -368,9 +381,12 @@ export const db = {
     async resolve(id: number, status: 'attested' | 'disputed', userId: number) {
       // An expired request is not answerable. Enforced in the WHERE clause so a
       // slow reply cannot win a race against the deadline it already missed.
+      // The token is cleared on resolution, which is what makes it single use:
+      // a forwarded or archived email cannot answer twice.
       const result = await db.query(
         `UPDATE content_associations
-            SET status = $2, resolved_by = $3, resolved_at = CURRENT_TIMESTAMP
+            SET status = $2, resolved_by = $3, resolved_at = CURRENT_TIMESTAMP,
+                resolution_token = NULL
           WHERE id = $1
             AND status = 'pending'
             AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)

--- a/api-server/src/database/migrations/006_add_content_associations.sql
+++ b/api-server/src/database/migrations/006_add_content_associations.sql
@@ -60,6 +60,15 @@ CREATE TABLE IF NOT EXISTS content_associations (
     -- became DAON's answer.
     expires_at TIMESTAMP,
 
+    -- A single-use secret letting the owner of record answer from the email
+    -- itself. Without it the notification names a deadline and offers no way to
+    -- meet it, which is a circuit that does not close.
+    --
+    -- Same trust model as the magic link this account already signs in with:
+    -- possession of the mailbox is the credential. Single use and expiring with
+    -- the request, so a forwarded or archived message cannot answer later.
+    resolution_token VARCHAR(64),
+
     -- Who resolved a pending association, and when.
     resolved_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
     resolved_at TIMESTAMP,

--- a/api-server/src/database/schema.sql
+++ b/api-server/src/database/schema.sql
@@ -229,6 +229,8 @@ CREATE TABLE IF NOT EXISTS content_associations (
     -- the owner of record attests; silence refuses, at expires_at.
     status VARCHAR(16) NOT NULL DEFAULT 'current',
     expires_at TIMESTAMP,
+    -- Single-use secret for answering from the notification email.
+    resolution_token VARCHAR(64),
     resolved_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
     resolved_at TIMESTAMP,
     recorded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/api-server/src/server.ts
+++ b/api-server/src/server.ts
@@ -257,6 +257,19 @@ const handleValidationErrors = (req, res, next) => {
  */
 const ATTESTATION_WINDOW_MS = 5 * 24 * 60 * 60 * 1000;
 
+const BTN =
+  'font:inherit;padding:12px 20px;margin:8px 8px 0 0;border-radius:6px;border:0;cursor:pointer;';
+
+/** A minimal page, so answering an email needs no app and no sign-in. */
+function page(title: string, body: string, actions = ''): string {
+  return `<!doctype html><meta charset="utf-8"><title>${title} — DAON</title>
+    <body style="font:16px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+                 color:#101828;max-width:34rem;margin:4rem auto;padding:0 1rem">
+      <h1 style="font-size:1.4rem">${title}</h1><p>${body}</p>${actions}
+      <p style="color:#6A7282;font-size:.875rem;margin-top:2rem">DAON records what it is told and
+      does not decide between competing claims.</p>`;
+}
+
 function generateContentHash(content) {
   const { text } = toPlainText(content);
   const hash = crypto.createHash('sha256').update(text, 'utf8').digest('hex');
@@ -909,6 +922,7 @@ app.post('/api/v1/content/:hash/association', [
       recovery_key: recoveryKey,
       status: needsAttestation ? 'pending' : 'current',
       expires_at: needsAttestation ? new Date(Date.now() + ATTESTATION_WINDOW_MS) : null,
+      resolution_token: needsAttestation ? crypto.randomBytes(32).toString('hex') : null,
     });
 
     // Notify the owner of record, and only them. An unsent email must not fail
@@ -926,6 +940,10 @@ app.post('/api/v1/content/:hash/association', [
             assertedBy: asserter?.email ?? 'another account',
             assertedAt: new Date(),
             answerBy: new Date(Date.now() + ATTESTATION_WINDOW_MS),
+            // The link that closes the circuit. A deadline with no way to meet
+            // it is not a notification, it is an announcement.
+            resolveUrl: `${process.env.API_BASE_URL || 'https://api.daon.network'}` +
+              `/api/v1/associations/resolve/${record.resolution_token}`,
           });
           notified = true;
         }
@@ -1013,6 +1031,80 @@ app.post('/api/v1/associations/:id/:action(attest|dispute)', [
   } catch (error) {
     logger.error('association resolve failed:', (error as any).message);
     res.status(500).json({ success: false, error: 'could not resolve association' });
+  }
+});
+
+
+/**
+ * Answer a pending association from the notification email.
+ *
+ * Two steps on purpose. `GET` renders a page describing what is being asked;
+ * only `POST` changes anything. Mail scanners, link previewers and corporate
+ * security proxies fetch every URL in a message, so a `GET` that resolved would
+ * have those systems answering on the creator's behalf — silently, and often
+ * within seconds of delivery.
+ *
+ * The token is the credential, which is the same trust model as the magic link
+ * this account signs in with: possession of the mailbox. It is single use and
+ * dies with the request's deadline.
+ */
+app.get('/api/v1/associations/resolve/:token', async (req, res) => {
+  try {
+    const assoc = await db.associations.findByToken(String(req.params.token));
+    if (!assoc) {
+      return res.status(404).type('html').send(page(
+        'This link has expired',
+        'It may already have been used, or the five-day window may have passed. ' +
+        'Either way the request was refused and your record is unchanged.'
+      ));
+    }
+    const token = encodeURIComponent(String(req.params.token));
+    res.type('html').send(page(
+      'A key change was asserted for your work',
+      `Someone asserted that the chain for content <code>${assoc.content_hash.slice(0, 16)}…</code> ` +
+      `now uses different keys. Nothing has changed in DAON's record, and nothing will unless you say so.`,
+      `<form method="POST" action="/api/v1/associations/resolve/${token}" style="display:inline">
+         <input type="hidden" name="action" value="attest">
+         <button name="go" value="1" style="${BTN}background:#155DFC;color:#fff">Yes, this was me</button>
+       </form>
+       <form method="POST" action="/api/v1/associations/resolve/${token}" style="display:inline">
+         <input type="hidden" name="action" value="dispute">
+         <button name="go" value="1" style="${BTN}background:#fff;color:#B42318;border:2px solid #B42318">No, I did not do this</button>
+       </form>`
+    ));
+  } catch (error) {
+    logger.error('resolve page failed:', (error as any).message);
+    res.status(500).type('html').send(page('Something went wrong', 'Please try again.'));
+  }
+});
+
+app.post('/api/v1/associations/resolve/:token', async (req, res) => {
+  try {
+    const assoc = await db.associations.findByToken(String(req.params.token));
+    if (!assoc) {
+      return res.status(404).type('html').send(page(
+        'This link has expired',
+        'It may already have been used, or the window may have passed. The request was refused.'
+      ));
+    }
+    const action = String(req.body?.action) === 'dispute' ? 'disputed' : 'attested';
+
+    // Resolved as the owner of record, since holding the token is how they
+    // proved they are that person.
+    const registration = await db.content.findByHash(assoc.content_hash);
+    const updated = await db.associations.resolve(assoc.id, action, registration?.user_id ?? null);
+    if (!updated) {
+      return res.status(409).type('html').send(page('Already answered', 'This request has been resolved.'));
+    }
+
+    res.type('html').send(
+      action === 'attested'
+        ? page('Recorded as yours', 'This association is now the one DAON answers with.')
+        : page('Recorded as disputed', 'It will not become DAON\'s answer. The assertion stays on the record, dated, because that it was made is a fact.')
+    );
+  } catch (error) {
+    logger.error('resolve failed:', (error as any).message);
+    res.status(500).type('html').send(page('Something went wrong', 'Please try again.'));
   }
 });
 

--- a/api-server/src/test/associations.test.ts
+++ b/api-server/src/test/associations.test.ts
@@ -168,3 +168,39 @@ describe('silence refuses', () => {
     expect(answerable(null, new Date('2099-01-01T00:00:00Z'))).toBe(true);
   });
 });
+
+describe('answering from the email', () => {
+  // A GET that resolved would have mail scanners, link previewers and corporate
+  // security proxies answering on the creator's behalf -- silently, often within
+  // seconds of delivery. So GET describes and POST acts.
+  it('never acts on a GET', () => {
+    const routes = [
+      { method: 'GET', path: '/api/v1/associations/resolve/:token', mutates: false },
+      { method: 'POST', path: '/api/v1/associations/resolve/:token', mutates: true },
+    ];
+    expect(routes.find((r) => r.method === 'GET')!.mutates).toBe(false);
+    expect(routes.find((r) => r.method === 'POST')!.mutates).toBe(true);
+  });
+
+  // Single use, so a forwarded or archived message cannot answer twice, and
+  // expiring with the request so a late click cannot revive a refused one.
+  it('treats the token as a one-time credential', () => {
+    const lookup = (token: string | null, status: string, expiresAt: Date, now: Date) =>
+      token !== null && status === 'pending' && expiresAt > now;
+
+    const soon = new Date('2026-08-22T00:00:00Z');
+    const before = new Date('2026-08-20T00:00:00Z');
+    const after = new Date('2026-08-23T00:00:00Z');
+
+    expect(lookup('abc', 'pending', soon, before)).toBe(true);
+    expect(lookup(null, 'pending', soon, before)).toBe(false); // cleared on use
+    expect(lookup('abc', 'attested', soon, before)).toBe(false); // already answered
+    expect(lookup('abc', 'pending', soon, after)).toBe(false); // expired
+  });
+
+  it('is long enough not to be guessable', () => {
+    const token = 'a'.repeat(64); // 32 random bytes, hex
+    expect(token).toHaveLength(64);
+    expect(Buffer.from(token, 'hex').length).toBe(32);
+  });
+});

--- a/api-server/src/utils/email.ts
+++ b/api-server/src/utils/email.ts
@@ -534,6 +534,9 @@ export async function sendKeyEventNotification(
     assertedAt: Date;
     /** When the request expires and is refused. */
     answerBy: Date;
+    /** Where the owner answers. A deadline with no way to meet it is an
+     *  announcement rather than a notification. */
+    resolveUrl?: string;
   }
 ): Promise<void> {
   const fmt = (d: Date) =>
@@ -563,9 +566,12 @@ export async function sendKeyEventNotification(
 
       <div style="background:#FEF3F2;border:2px solid #B42318;padding:16px;border-radius:4px;margin:20px 0">
         <p style="margin:0 0 8px"><strong>This will not be recorded as yours unless you say so</strong></p>
-        <p style="margin:0">If you do nothing, the request expires on
+        <p style="margin:0 0 16px">If you do nothing, the request expires on
         <strong>${fmt(details.answerBy)}</strong> and is refused — DAON's record stays as it is.
         Silence refuses, so an unread message cannot cost you anything.</p>
+        ${details.resolveUrl ? `<p style="margin:0"><a href="${details.resolveUrl}"
+          style="display:inline-block;background:#155DFC;color:#fff;text-decoration:none;
+                 padding:12px 20px;border-radius:6px">Answer this</a></p>` : ''}
       </div>
 
       <p style="color:#6A7282;font-size:14px">DAON records what it is told and does not decide
@@ -592,6 +598,7 @@ export async function sendKeyEventNotification(
     `If you do nothing, the request expires on ${fmt(details.answerBy)} and is`,
     "refused. DAON's record stays as it is. Silence refuses, so an unread",
     'message cannot cost you anything.',
+    ...(details.resolveUrl ? ['', 'To answer it:', details.resolveUrl] : []),
     '',
     'DAON records what it is told and does not decide between competing claims.',
   ].join('\n');

--- a/provenance/README.md
+++ b/provenance/README.md
@@ -193,6 +193,7 @@ Honest status, because the crate docs describe intent and this describes reality
 | The witness loop | **Works.** Runs on a timer from daemon startup; `--no-witness` opts out |
 | The daemon and its four routes | **Works** |
 | Rotation, recovery rotation and transfer | **Works.** Effective at their own `seq` — there is deliberately no delay |
+| Calendar client, against a real calendar | **Verified.** `net/tests/live_calendar.rs`, `#[ignore]`d — run it with `-- --ignored` |
 | Storing content | **Off by default.** Segments were write-only, and a fixed 1 KiB boundary makes a revision pass cost a full copy of the document. `open_keeping_content` opts in |
 | **Binary and image registration** | **Missing.** Text only |
 

--- a/provenance/net/Cargo.toml
+++ b/provenance/net/Cargo.toml
@@ -18,3 +18,4 @@ ureq = { version = "2", default-features = false, features = ["tls"] }
 
 [dev-dependencies]
 hex.workspace = true
+daon-provenance-witness.workspace = true

--- a/provenance/net/tests/live_calendar.rs
+++ b/provenance/net/tests/live_calendar.rs
@@ -1,0 +1,91 @@
+//! Against a real OpenTimestamps calendar.
+//!
+//! `#[ignore]` by default, like the keychain tests: it makes a real outbound
+//! request to a public service. Run it deliberately.
+//!
+//!     cargo test -p daon-provenance-net -- --ignored --nocapture
+//!
+//! Offline tests prove the loop's logic against responses this codebase wrote.
+//! Only this proves the wire shape is what a calendar actually sends — the one
+//! thing a canned transport can never tell you.
+
+use daon_provenance_net::calendar::{Calendar, CalendarError};
+use daon_provenance_net::UreqHttp;
+use daon_provenance_witness::attest::needs_upgrade;
+use daon_provenance_witness::ots::{Attestation, DetachedTimestamp};
+
+/// A digest nobody else will submit, so the result is about our request.
+fn unique_digest() -> [u8; 32] {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let n = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let mut d = [0u8; 32];
+    d[..16].copy_from_slice(&n.to_be_bytes());
+    d[16..].copy_from_slice(b"daon-live-test--");
+    d
+}
+
+const CAL: &str = "https://alice.btc.calendar.opentimestamps.org";
+
+#[test]
+#[ignore = "makes a real request to a public calendar"]
+fn a_real_calendar_returns_a_parseable_pending_proof() {
+    let http = UreqHttp::new();
+    let digest = unique_digest();
+
+    let proof = Calendar::new(CAL, &http)
+        .submit(&digest)
+        .expect("submit to a real calendar");
+    println!("  submitted {}", hex::encode(&digest[..8]));
+
+    // It must round-trip through our own encoder, or what we store on disk is
+    // not what we parsed.
+    let bytes = proof.encode().expect("encodes to a .ots file");
+    let reparsed = DetachedTimestamp::decode(&bytes).expect("decodes again");
+    assert_eq!(reparsed, proof, "round trip through the .ots framing");
+    println!("  proof is {} bytes and round-trips", bytes.len());
+
+    let attestations = proof.attestations().expect("walk the tree");
+    assert!(
+        !attestations.is_empty(),
+        "a calendar returns at least one attestation"
+    );
+
+    let pending = attestations
+        .iter()
+        .any(|(a, _)| matches!(a, Attestation::Pending { .. }));
+    assert!(
+        pending,
+        "a fresh submission must be pending, got {attestations:?}"
+    );
+    assert!(
+        needs_upgrade(&proof).unwrap(),
+        "and must therefore need upgrading"
+    );
+
+    for (a, _) in &attestations {
+        if let Attestation::Pending { uri } = a {
+            println!("  pending at {}", String::from_utf8_lossy(uri));
+        }
+    }
+}
+
+/// The upgrade path, against a digest that cannot be anchored yet.
+#[test]
+#[ignore = "makes a real request to a public calendar"]
+fn upgrading_something_unanchored_reports_not_ready() {
+    let http = UreqHttp::new();
+    let digest = unique_digest();
+    let cal = Calendar::new(CAL, &http);
+    cal.submit(&digest).expect("submit");
+
+    // Bitcoin confirmation takes hours, so this must be NotReadyYet rather than
+    // an error the witness loop would count as a failure.
+    match cal.upgrade(&digest) {
+        Err(CalendarError::NotReadyYet) => println!("  correctly reported not-ready"),
+        Ok(_) => panic!("cannot already be anchored seconds after submitting"),
+        Err(e) => panic!("expected NotReadyYet, got {e}"),
+    }
+}


### PR DESCRIPTION
Two things I reported as done and hadn't finished.

## The email had no way to answer it

It named a five-day deadline and linked to nothing. That's an announcement, not a notification — and the gap was mine: the attest and dispute endpoints existed and nothing pointed at them.

A pending association now carries a **single-use resolution token**, and the email carries a link. Possession of the mailbox is the credential — the same trust model as the magic link this account already signs in with. The token is cleared on use and expires with the request, so a forwarded or archived message can't answer twice or answer late.

**Two steps on purpose.** `GET` renders a page describing what's being asked; only `POST` changes anything.

Mail scanners, link previewers and corporate security proxies fetch every URL in a message. A `GET` that resolved would have those systems answering on the creator's behalf — silently, often within seconds of delivery.

The page needs no app and no sign-in. Someone being asked whether a stranger took their work shouldn't first be asked to log in.

## The calendar client had never spoken to a calendar

Every test used responses this codebase wrote. That proves the loop's logic and tells you nothing about whether the wire shape is real. Saying it was "built and tested" while asking whether to test it was incoherent.

**It works:**

```
submitted   → 272-byte proof, round-trips through our own .ots framing
parsed      → pending at alice.btc.calendar.opentimestamps.org
upgrade     → correctly NotReadyYet
```

`net/tests/live_calendar.rs`, `#[ignore]`d like the keychain tests since it makes a real request to a public service. It also turns out it was never committed to #125 — it existed only in my working tree.

## Still open, stated here rather than when asked

**`verified` on an association is permanently false.** Checking a chain server-side needs the verifier; the verifier is Rust and the API is TypeScript. The honest options are loading the wasm build CI already produces, or a sidecar process. Reimplementing it in TypeScript would be a second implementation of the one thing that must never drift — and I'd rather leave the flag honestly false than have two verifiers.