### PR TITLE
fix(ci): build the validator image for amd64 only, so deploys finish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -159,7 +159,17 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./daon-core
-          platforms: linux/amd64,linux/arm64
+          # amd64 only, matching production (x86_64) and pr.yml.
+          #
+          # The runner is amd64, so arm64 is built under QEMU, and cross-compiling
+          # Go that way is slow enough to blow the 15-minute budget: the amd64
+          # stages finished in seconds while arm64's `go build` ran for eleven
+          # minutes and was still going when the job was killed. That cancelled the
+          # deploy of a security update the checks had already passed.
+          #
+          # release.yml still builds both, which is where multi-arch belongs --
+          # that artifact is for other people's machines. This one is for ours.
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## What happened

Merging #120 — a security bump to the Go modules backing `daon-blockchain`, **which runs in production** — kicked off a deploy that was **cancelled after 15 minutes**. `Deploy to Production` was skipped. The security fix is not live.

## Why

`Build Validator Image` builds `linux/amd64,linux/arm64` on an amd64 runner, so arm64 goes through QEMU:

```
17:43:34  #29 [linux/amd64 stage-1 4/6] COPY ... DONE 0.7s
17:43:34  #26 [linux/arm64 builder 7/7] RUN go build ...
17:54:25  ##[error]The operation was canceled.
```

amd64 finished in seconds. arm64 ran for eleven minutes and was still going when the timeout hit. `deploy` has `needs: build-validator`, so it never ran.

`pr.yml` already builds amd64 only — which is why this same build passed on the PR in 5m18s and then failed on merge.

## The fix

Drop arm64 here. Production is `x86_64` running a `linux/amd64` image; nothing consumed the arm64 half. `release.yml` keeps both — that artifact is for other people's machines.

## One thing I found and did not change

The image this job pushes **is not what production runs.** `docker-compose.yml:5-9` gives `daon-blockchain` a `build:` stanza, so the server compiles from source. A registry push that nothing pulls is currently able to block a deploy.

Unpicking that is a design decision rather than a fix, so it is flagged here and in the commit message rather than done quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EdAzmVtvNSJHgwbKHsiMu