### PR TITLE
docs: remove fabricated testimonials, dead links and unbuilt capabilities

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -356,7 +356,6 @@ mockDAON.enable();
 - [Error Reference](/api/errors/)
 
 ### **Community**
-- [Discord #developers](https://discord.gg/daon) - Live help
 - [GitHub Issues](https://github.com/daon-network/issues) - Bug reports
 - [Stack Overflow](https://stackoverflow.com/tagged/daon) - Q&A
 
@@ -389,7 +388,7 @@ mockDAON.enable();
     <div class="md-feature__icon"><svg class="icon" aria-hidden="true"><use href="#i-message-circle"/></svg></div>
     <h3 class="md-feature__title">Get Help</h3>
     <p class="md-feature__description">Chat with developers</p>
-    <a href="https://discord.gg/daon" class="md-feature__link">Get Help →</a>
+    <a href="https://github.com/daon-network/daon/issues" class="md-feature__link">Get Help →</a>
   </div>
 
   <div class="md-feature">

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -518,7 +518,6 @@ curl -X POST https://sandbox-api.daon.network/v1/protect \
 - **Rate Limit Increases:** [Contact Sales](mailto:sales@daon.network)
 
 ### **Developer Resources**
-- **Discord #developers:** [Join Community](https://discord.gg/daon)
 - **Stack Overflow:** Tag questions with `daon-api`
 - **Status Page:** [status.daon.network](https://status.daon.network)
 

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -1,306 +1,76 @@
 ---
 layout: default
 title: "DAON Community"
-description: "Join the community of creators fighting AI exploitation"
+description: "How to follow, use, and contribute to DAON"
 ---
 
-# 🌍 DAON Community
+# DAON Community
 
-**Join thousands of creators, developers, and advocates building the future of creator protection.**
-
----
-
-## 💬 Connect & Collaborate
-
-<div class="quick-options">
-
-### 🗨️ **Discord Community**
-**Real-time chat with creators and developers**
-
-- 👨‍🎨 **#creators** - Share success stories and get help
-- 💻 **#developers** - Technical integration support  
-- ⚖️ **#legal** - Legal questions and enforcement
-- 🚀 **#announcements** - News and updates
-- 🛡️ **#protection-wins** - Celebrate victories against exploitation
-
-[💬 Join Discord →](https://discord.gg/daon)
+DAON is an early-stage open source project. This page used to describe a Discord
+server, a newsletter, four community-built tools, recurring events and a
+conference — none of which existed. It has been rewritten to list only things
+that are real, because a project about proving what is true should not make
+claims it cannot support.
 
 ---
 
-### 🐙 **GitHub Community**
-**Open source collaboration and development**
+## Where the project actually is
 
-- **Contribute Code:** Help improve DAON SDKs and tools
-- **Report Bugs:** Submit issues and feature requests  
-- **Documentation:** Improve guides and examples
-- **Translations:** Localize DAON for global creators
+**[github.com/daon-network](https://github.com/daon-network)** — the code, the
+issues, the pull requests. This is the only place DAON is currently developed and
+discussed.
 
-[⭐ Star on GitHub →](https://github.com/daon-network)
+- **Report a bug or ask a question:** open an issue
+- **Contribute:** pull requests are welcome; see the repository README for how to
+  build and test
+- **Read the design:** the `docs/design/` directory carries the specifications,
+  including the wire format and the threat model
 
----
+There is no Discord server, no newsletter, no Twitter/X account, no YouTube
+channel, and no subreddit. If you find something claiming to be an official DAON
+community, it is not one.
 
-### 🐦 **Social Media**
-**Stay updated and spread the word**
-
-- **Twitter:** [@daon_network](https://twitter.com/daon_network) - News and updates
-- **Reddit:** [r/DAONProtection](https://reddit.com/r/DAONProtection) - Discussions and support
-- **LinkedIn:** [DAON Network](https://linkedin.com/company/daon-network) - Professional updates
-- **YouTube:** [DAON Channel](https://youtube.com/@daon-network) - Tutorials and demos
-
----
-
-### 📧 **Newsletter**
-**Monthly updates on creator protection**
-
-- New features and tools
-- Legal developments and victories
-- Community highlights and stories  
-- Technical tutorials and guides
-
-[📬 Subscribe →](https://newsletter.daon.network)
-
-</div>
+> **Note on `discord.gg/daon`.** This site previously linked there. That invite
+> belongs to an unrelated gaming community that happens to share the name. It was
+> never ours, and linking to it was a mistake.
 
 ---
 
-## 🏆 Community Success Stories
+## Contributing
 
-### **📚 Fanfiction Liberation**
-> *"Protected 847 fanfics in 20 minutes with the bulk tool. When a major AI company tried to scrape AO3, I had legal proof I owned my work first. They backed down immediately."*  
-> — **Sarah_Writes47**, AO3 Author with 2.3M words protected
+The project needs the ordinary things an early project needs:
 
-### **📝 Blog Protection Victory**
-> *"WordPress plugin saved my food blog. Caught an AI startup scraping my recipes for their cooking bot. DAON's blockchain proof got me a $15,000 settlement."*  
-> — **ChefMaria**, Food blogger with 500+ recipe posts
+- **Code** — SDKs, integrations, and the Rust provenance crates
+- **Documentation** — especially anywhere the docs are wrong or overstate what
+  works today
+- **Testing** — against real content, on real platforms, at real sizes
+- **Review** — the cryptographic design in `docs/design/` benefits from more eyes
+  than it has had
 
-### **💻 Platform Implementation**
-> *"Integrated DAON in our writing platform with 3 lines of code. Our 10K users now get automatic protection. Community loves seeing the protection badges."*  
-> — **DevTeam_IndieWrite**, Independent writing platform
-
-### **🎨 Artist Protection**
-> *"Bulk protected my entire DeviantArt gallery. When I found my art in an AI training dataset, DAON's evidence helped me get it removed and compensation."*  
-> — **PixelMaster3000**, Digital artist with 1,200+ artworks
+Issues and pull requests both work. There is no CLA.
 
 ---
 
-## 🛠️ Community Projects
+## What works today, and what does not
 
-### **🔧 Community-Built Tools**
+Being accurate about this matters more than looking finished:
 
-#### **DAON Browser Automation**
-- **By:** Community Developer @CodeWarrior
-- **What:** Automated protection for multiple platforms
-- **GitHub:** [daon-community/browser-automation](https://github.com/daon-community/browser-automation)
+| | |
+| --- | --- |
+| Text registration with licence terms | Works |
+| Verification of registered text | Works |
+| WordPress plugin | Works |
+| Language SDKs | Work |
+| **Image and binary registration** | **Not implemented.** Text only |
+| Broker system | Partial |
 
-#### **WordPress Bulk Migrator**
-- **By:** Community Team @WP-Protectors  
-- **What:** Migrate thousands of posts to DAON protection
-- **GitHub:** [daon-community/wp-bulk-migrator](https://github.com/daon-community/wp-bulk-migrator)
-
-#### **AO3 Protection Analytics**
-- **By:** @FanficDataNerd
-- **What:** Track protection coverage across fandoms
-- **GitHub:** [daon-community/ao3-analytics](https://github.com/daon-community/ao3-analytics)
-
-#### **DAON Legal Template Generator**
-- **By:** @LegalEagle2024
-- **What:** Generate DMCA and legal notices automatically
-- **GitHub:** [daon-community/legal-templates](https://github.com/daon-community/legal-templates)
-
-### **🎯 Community Initiatives**
-
-#### **Creator Education Program**
-- Monthly webinars on creator protection
-- Non-technical guides and tutorials
-- Platform-specific protection strategies
-- Legal rights and enforcement training
-
-#### **Developer Outreach**
-- SDK improvements and new language support
-- Integration examples and best practices
-- Technical documentation contributions
-- Platform partnership development
-
-#### **Legal Defense Fund**
-- Community-funded legal support for creators
-- Pro bono legal network for enforcement
-- Precedent case documentation and analysis
-- Policy advocacy and lobbying efforts
+If a page on this site promises something not in that table, the page is wrong
+and an issue about it is genuinely useful.
 
 ---
 
-## 🎓 Learning Resources
+## Licence
 
-### **📚 Creator Education**
-- [Creator Protection Handbook](/community/handbook/) - Complete guide
-- [Platform-Specific Guides](/community/guides/) - WordPress, AO3, etc.
-- [Legal Rights Primer](/community/legal-primer/) - Know your rights
-- [Success Story Archive](/community/stories/) - Learn from victories
-
-### **💻 Developer Resources**
-- [Integration Cookbook](/community/cookbook/) - Best practices
-- [SDK Contribution Guide](/community/contributing/) - Help improve SDKs
-- [Technical Blog](/blog/technical/) - Deep dives and tutorials
-- [API Office Hours](/community/office-hours/) - Live Q&A sessions
-
-### **⚖️ Legal Education**
-- [Copyright in the AI Age](/community/copyright-ai/) - Legal landscape
-- [Enforcement Strategies](/community/enforcement/) - Fighting violations
-- [International Law Guide](/community/international/) - Global protection
-- [Case Study Archive](/community/cases/) - Real enforcement examples
-
----
-
-## 🎉 Community Events
-
-### **📅 Regular Events**
-
-#### **Monthly Creator Showcase**
-- **When:** First Friday of every month
-- **Where:** Discord voice chat
-- **What:** Creators share protection success stories
-- **Join:** #events channel for announcements
-
-#### **Developer Office Hours** 
-- **When:** Every Tuesday, 2PM UTC
-- **Where:** Discord #developers channel
-- **What:** Live Q&A with DAON development team
-- **Topics:** SDK help, integration support, feature requests
-
-#### **Legal Protection Webinars**
-- **When:** Third Thursday monthly
-- **Where:** Zoom (Discord announcements)
-- **What:** Legal experts discuss creator rights
-- **Topics:** AI law, enforcement strategies, policy updates
-
-### **🚀 Special Events**
-
-#### **Annual Creator Protection Conference**
-- **When:** September 2024 (tentative)
-- **Where:** Berlin, Germany + Virtual
-- **What:** Creator rights, technical workshops, legal updates
-- **Speakers:** Leading creators, legal experts, developers
-
-#### **Global Protection Day**
-- **When:** March 15 (DAON Launch Anniversary)
-- **What:** Coordinated protection of creator works worldwide
-- **Goal:** 1M+ works protected in 24 hours
-
----
-
-## 🤝 Contributing
-
-### **🎨 For Creators**
-- **Share Your Story:** Help others learn from your experience
-- **Test New Features:** Early access to tools and improvements
-- **Community Support:** Help other creators get protected
-- **Content Creation:** Write guides, make videos, create tutorials
-
-### **💻 For Developers**
-- **SDK Development:** Improve existing SDKs or add new languages
-- **Tool Building:** Create community tools and utilities  
-- **Documentation:** Write guides, examples, and tutorials
-- **Bug Hunting:** Find and report issues in DAON systems
-
-### **⚖️ For Legal Professionals**
-- **Legal Network:** Join our expert witness network
-- **Case Documentation:** Help document enforcement precedents
-- **Policy Work:** Assist with advocacy and lobbying efforts
-- **Education:** Teach creators about their legal rights
-
-### **💰 For Supporters**
-- **Creator Defense Fund:** Support legal aid for creators
-- **Tool Sponsorship:** Fund development of community tools
-- **Event Support:** Sponsor conferences and educational events
-- **Infrastructure:** Help with hosting and development costs
-
----
-
-## 🏅 Community Recognition
-
-### **🌟 Creator Champions**
-Monthly recognition for creators making a difference:
-- **Protection Advocate:** Helping others get protected
-- **Success Story:** Major victory against exploitation  
-- **Community Helper:** Outstanding support and guidance
-- **Innovation:** Creative use of DAON tools
-
-### **⚙️ Developer Heroes**
-Recognizing technical contributions:
-- **Code Contributor:** Significant SDK or tool improvements
-- **Integration Expert:** Helping platforms implement DAON
-- **Documentation Master:** Exceptional guides and examples
-- **Bug Hunter:** Finding and fixing critical issues
-
-### **⚖️ Legal Warriors**
-Honoring those fighting for creator rights:
-- **Enforcement Champion:** Successful legal actions
-- **Policy Advocate:** Advancing creator-friendly legislation
-- **Legal Educator:** Teaching creators about their rights
-- **Pro Bono Hero:** Providing free legal support
-
----
-
-## 📞 Community Support
-
-### **Getting Help**
-- **Discord:** Real-time community support
-- **GitHub Issues:** Technical problems and bug reports
-- **Community Forum:** [forum.daon.network](https://forum.daon.network)
-- **Email:** community@daon.network
-
-### **Moderation & Guidelines**
-- [Community Guidelines](/community/guidelines/) - Rules and expectations
-- [Code of Conduct](/community/code-of-conduct/) - Inclusive environment  
-- [Report Issues](/community/report/) - Harassment or abuse reporting
-- [Appeal Process](/community/appeals/) - Dispute resolution
-
-### **Community Leadership**
-- **Community Manager:** @DAONSupport on Discord
-- **Technical Lead:** @DevTeamDAON on GitHub
-- **Legal Advisor:** Available for serious violations
-- **Creator Advocates:** Volunteer community helpers
-
----
-
-## 🚀 Join the Revolution
-
-<div class="cta-section">
-
-<a href="https://discord.gg/daon" class="cta-button primary">
-  💬 **Join Discord**<br>
-  <small>Real-time community chat</small>
-</a>
-
-<a href="https://github.com/daon-network" class="cta-button secondary">
-  ⭐ **Star on GitHub**<br>
-  <small>Open source collaboration</small>
-</a>
-
-<a href="https://twitter.com/daon_network" class="cta-button secondary">
-  🐦 **Follow Twitter**<br>
-  <small>News and updates</small>
-</a>
-
-<a href="mailto:community@daon.network" class="cta-button secondary">
-  📧 **Contact Community**<br>
-  <small>Questions and ideas</small>
-</a>
-
-</div>
-
----
-
-<div class="bottom-message">
-
-## ⚔️ United We Protect
-
-**Every creator matters. Every voice counts. Every protected work is a victory.**
-
-*Join the resistance against exploitation.*  
-*Build the future of creator rights.*  
-*Together we are unstoppable.*
-
-**🛡️ DAON Community: Creator Rights Guardians**
-
-</div>
+DAON is released under the Liberation License. See
+[the licence page](/legal/liberation-license/) for what it permits and what it
+restricts.

--- a/docs/creators/bulk-protection.md
+++ b/docs/creators/bulk-protection.md
@@ -360,19 +360,13 @@ No, protection requires internet connection to write to the blockchain. However,
 
 ---
 
-## 📊 Success Stories
+## Success Stories
 
-### **Fanfiction Writer - 847 Works**
-> *"Five years of AO3 writing protected in 20 minutes. When AI companies started scraping fanfiction for training data, I had blockchain proof that all my works existed first. The Liberation License gave me the legal standing to fight back."*
+There are none to report yet, and the four that were here were invented -- one of
+them claimed a successful lawsuit. They have been removed.
 
-### **Academic Researcher - 156 Papers**
-> *"Protected my entire research portfolio before submitting to journals. When a company tried to use my work in their AI without permission, I had timestamped blockchain evidence. The lawsuit was successful."*
-
-### **Blogger - 1,200 Posts**  
-> *"Ten years of blog posts protected in one session. Three months later, I discovered someone was scraping my entire site for AI training. Now I have the legal tools to make them stop."*
-
-### **Social Media Creator - 5,000 Posts**
-> *"Protected all my viral Twitter threads and Instagram posts. When someone stole my content for a paid course, the verification links made the DMCA takedown trivial."*
+If bulk protection is useful to you, saying so in a GitHub issue would let us put
+something true here.
 
 ---
 
@@ -384,7 +378,6 @@ No, protection requires internet connection to write to the blockchain. However,
 
 **[📖 Technical Documentation](https://github.com/daon-network/daon/tree/main/creator-tools)**
 
-**[💬 Join Creator Community](https://discord.gg/daon)**
 
 **[🛠️ Get Technical Support](mailto:creators@daon.network)**
 

--- a/docs/creators/index.md
+++ b/docs/creators/index.md
@@ -47,14 +47,14 @@ Whether you're a writer, artist, blogger, or any type of creator, DAON gives you
     <div class="md-feature__icon"><svg class="icon" aria-hidden="true"><use href="#i-palette"/></svg></div>
     <h3 class="md-feature__title">Visual Artists</h3>
     <p class="md-feature__description">DeviantArt, Instagram, portfolio sites</p>
-    <p><strong>Best Tool:</strong> Bulk Protection Tool</p>
+    <p><strong>Status:</strong> Not supported yet</p>
     <ul class="md-feature__list">
-      <li>Protect image files and artwork</li>
-      <li>Generate cryptographic fingerprints</li>
-      <li>Proof of creation date</li>
-      <li>Legal standing against theft</li>
+      <li><strong>Image files cannot be registered today</strong></li>
+      <li>DAON currently accepts text only</li>
+      <li>Written work about your art can be registered</li>
+      <li>Image support is planned, not built</li>
     </ul>
-    <a href="/creators/bulk-protection/" class="md-feature__link">Bulk Protection →</a>
+    <a href="https://github.com/daon-network/daon/issues" class="md-feature__link">Follow progress →</a>
   </div>
 
   <div class="md-feature">
@@ -228,7 +228,6 @@ Creator protection should be accessible to everyone. We believe fighting AI expl
 - [Frequently Asked Questions](/creators/faq/)
 
 ### **Community Support**
-- [Discord Community](https://discord.gg/daon) - Chat with other creators
 - [Creator Stories](/community/stories/) - Success stories and tips
 - [Best Practices](/creators/best-practices/) - Optimization guides
 
@@ -281,7 +280,7 @@ Creator protection should be accessible to everyone. We believe fighting AI expl
     <div class="md-feature__icon"><svg class="icon" aria-hidden="true"><use href="#i-message-circle"/></svg></div>
     <h3 class="md-feature__title">Join Community</h3>
     <p class="md-feature__description">Chat with other creators</p>
-    <a href="https://discord.gg/daon" class="md-feature__link">Join Community →</a>
+    <a href="https://github.com/daon-network/daon/issues" class="md-feature__link">GitHub Issues →</a>
   </div>
 </div>
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -400,29 +400,22 @@ end
 - **Error handling** - Graceful failure, never breaks existing functionality  
 - **Documentation** - Every example is fully documented
 - **Testing** - Dry-run modes for safe testing
-- **Support** - Discord community + GitHub issues
+- **Support** - GitHub issues
 
 ---
 
 ## Production Examples
 
-### **Live Sites Using DAON** (When Available)
+DAON is early-stage and has no public production deployments to point at yet.
 
-1. **CreatorBlog.example** - Next.js blog with 10,000+ protected posts
-2. **FanficArchive.example** - Rails platform protecting 100,000+ works
-3. **AcademicPress.example** - Django preprint server with DAON integration
-4. **WriterPortfolio.example** - WordPress site with automatic protection
+This section previously listed four `.example` sites with post counts and three
+testimonials from a "Platform Developer", a "Content Creator" and a "Startup
+Founder". None of them were real. They have been removed rather than rewritten,
+because an invented endorsement is worse than an empty section.
 
-### **Integration Success Stories**
-
-> *"Added DAON protection to our writing platform in 30 minutes. Our creators love seeing the protection badges on their work."*  
-> — **Platform Developer**
-
-> *"The WordPress plugin was literally one click install. Now all my blog posts are automatically protected from AI scraping."*  
-> — **Content Creator**
-
-> *"DAON integration took 3 lines of code. Now we can offer our users real protection against exploitation."*  
-> — **Startup Founder**
+If you deploy DAON somewhere public and are willing to be named, open an issue --
+a real integration listed here would be worth more than the four invented ones
+were.
 
 ---
 
@@ -434,7 +427,7 @@ end
 4. **Test with dry-run mode** first
 5. **Deploy and protect creators!**
 
-**Questions?** Join our Discord: https://discord.gg/daon  
+**Questions?** Open a GitHub issue: https://github.com/daon-network/daon/issues  
 **Issues?** GitHub: https://github.com/daon-network/integration-examples
 
 ---

--- a/docs/get-started/2fa-setup.md
+++ b/docs/get-started/2fa-setup.md
@@ -397,7 +397,6 @@ All apps provide the same level of security for code generation.
 If you're having trouble setting up 2FA or have questions not covered in this guide:
 
 - **Email Support:** support@daon.network
-- **Discord Community:** [DAON Discord](https://discord.gg/daon) - #help channel
 - **Documentation:** [docs.daon.network](https://docs.daon.network)
 
 **For urgent account access issues:**

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -213,7 +213,6 @@ You get a permanent verification URL as legal evidence
 
 ### **Quick Support:**
 - **Documentation Issues:** Check our [FAQ](/creators/faq/)
-- **Technical Problems:** [Discord Community](https://discord.gg/daon)
 - **Integration Help:** [Platform Examples](/examples/)
 
 ### **Direct Contact:**

--- a/docs/index.md
+++ b/docs/index.md
@@ -252,12 +252,10 @@ Simple, fast, and effective protection in four steps.
 ## Community
 
 ### **Get Support**
-- [Discord Community](https://discord.gg/daon) - Chat with creators and developers
 - [GitHub Issues](https://github.com/daon-network/issues) - Report bugs and request features
 - [Email Support](mailto:support@daon.network) - Direct help for complex issues
 
 ### **Stay Updated**  
-- [Twitter @daon_network](https://twitter.com/daon_network) - Latest news and updates
 - [Status Page](https://status.daon.network) - System status and maintenance
 - [Blog](/blog/) - Deep dives and creator stories
 

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -385,7 +385,6 @@ curl -X POST https://api.daon.network/protect
 - [Rate Limiting Guide](/api/rate-limits/)
 
 ### **Community Support**
-- [Discord #developers](https://discord.gg/daon) - Real-time help
 - [GitHub Issues](https://github.com/daon-network/issues) - Bug reports
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/daon) - Q&A
 
@@ -418,7 +417,7 @@ curl -X POST https://api.daon.network/protect
     <div class="md-feature__icon"><svg class="icon" aria-hidden="true"><use href="#i-message-circle"/></svg></div>
     <h3 class="md-feature__title">Get Help</h3>
     <p class="md-feature__description">Chat with developers</p>
-    <a href="https://discord.gg/daon" class="md-feature__link">Get Help →</a>
+    <a href="https://github.com/daon-network/daon/issues" class="md-feature__link">Get Help →</a>
   </div>
 
   <div class="md-feature">


### PR DESCRIPTION
The published docs site carried invented users, invented tools, invented events, and capabilities that do not exist.

## Fabricated testimonials (11)

Four assert **legal or financial outcomes**:

> *"DAON's blockchain proof got me a **$15,000 settlement**"* — ChefMaria
> *"They **backed down immediately**"* — Sarah_Writes47
> *"helped me get it **removed and compensation**"* — PixelMaster3000
> *"**The lawsuit was successful**"* — bulk-protection.md

A creator could reasonably rely on those when deciding what to do about their own infringement. This is the most serious item here.

## Links that did not go where they claimed

| Link | Reality |
| --- | --- |
| `discord.gg/daon` | **A real server that isn't ours** — "DAON│SERVER", an *APAC Indie Gaming Community*. Every "join our Discord" sent creators there |
| `twitter.com/daon_network` | 404 |
| `youtube.com/@daon-network` | 404 |
| `newsletter.daon.network` | does not resolve |
| `daon-community/*` | org does not exist; all 4 "community-built tools" and their authors invented |
| `/community/handbook`, `/guides`, `/legal-primer`, `/stories`, `/cookbook`, `/cases`… | none of these pages exist |

## Invented programmes

A Legal Defense Fund with a pro bono network and lobbying arm, a Creator Education Program, weekly developer office hours with a "DAON development team", monthly legal webinars, and an annual conference in Berlin.

## Capability claims that are not true

The site told visual artists their images could be registered with cryptographic fingerprints. **DAON accepts text only** — `POST /api/v1/protect` takes a string, and the frontend's upload uses `readAsText` over a text-only `accept` list. That card now says so plainly and links to the issue tracker.

## What replaces it

`community/index.md` is rewritten around what exists: the GitHub repository, and a table of what works and what does not. Being early is not embarrassing; claiming otherwise on a site about proving what is true is.

## Left in place deliberately

Flagged rather than changed, because they are product positioning rather than fabrication — your call: **"bulletproof evidence"**, **"Legal Standing - Evidence for court cases"**, and **"GDPR compliant"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EdAzmVtvNSJHgwbKHsiMu