### PR TITLE
fix(ci): repair the deploy workflow YAML and check every workflow parses

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -304,10 +304,11 @@ jobs:
             for attempt in $(seq 1 30); do
               body=$(curl -fsS --max-time 10 https://api.daon.network/health 2>/dev/null || true)
               if [ -n "$body" ]; then
-                served=$(printf '%s' "$body" | python3 -c \
-                  "import sys,json
-try: print(json.load(sys.stdin).get('build',{}).get('commit','missing'))
-except Exception: print('unparseable')" 2>/dev/null || echo "unparseable")
+                # One line on purpose. A multi-line python -c here has to be
+                # indented to stay inside this block scalar, and unindented
+                # continuation lines silently end the YAML block -- which is
+                # exactly how this workflow became unparseable once already.
+                served=$(printf '%s' "$body" | python3 -c "import sys,json;print(json.load(sys.stdin).get('build',{}).get('commit','missing'))" 2>/dev/null || echo "unparseable")
                 [ "$served" = "${{ github.sha }}" ] && break
               fi
               echo "  waiting for the API to serve this build (${attempt}/30, last: ${served:-no response})"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,6 +63,41 @@ jobs:
             docs:
               - 'docs/**'
 
+  # ── CI itself ─────────────────────────────────────────────────────────────
+
+  workflows-parse:
+    name: Workflows Parse
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # A workflow file that does not parse fails at push time with "this run
+      # likely failed because of a workflow file issue" and no job log, so the
+      # first thing anyone learns is that a deploy did not happen. That is the
+      # same shape as the no-op deploys: CI reporting nothing rather than
+      # reporting a problem.
+      #
+      # The specific way it happened is worth knowing, because YAML invites it:
+      # a `run: |` block scalar ends at the first line indented less than the
+      # block, so an unindented continuation line inside a multi-line shell
+      # command silently terminates the block and everything after it is
+      # reparsed as YAML. It looks completely normal in a diff.
+      - name: Every workflow must parse
+        run: |
+          fail=0
+          for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+            [ -e "$f" ] || continue
+            if python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$f" 2>/tmp/err; then
+              echo "  ok      $f"
+            else
+              echo "::error file=$f::does not parse as YAML: $(tr '\n' ' ' < /tmp/err)"
+              fail=1
+            fi
+          done
+          exit $fail
+
   # ── API Server ────────────────────────────────────────────────────────────
 
   security:


### PR DESCRIPTION
## What I broke

The retry loop in #131 used a multi-line `python3 -c` whose continuation lines sat at column 0:

```yaml
              served=$(printf '%s' "$body" | python3 -c \
                "import sys,json
try: print(...)          # <- column 0 ends the block scalar
except Exception: ...
```

A YAML block scalar ends at the first line indented less than the block. Those lines silently terminated the `run:` block, and the next line containing a colon failed to parse as a mapping.

The failure mode is the bad one: **"this run likely failed because of a workflow file issue"** with no job and no log. The only symptom is that a deploy didn't happen. Two deploys failed this way.

## The fix

One line, with a comment saying why it has to stay one line.

## The systemic half

Nothing validated workflow files before merge, so an unparseable file reaches `main` and announces itself only by *not running* — the same shape as the three-month no-op deploys. This adds a **Workflows Parse** job that loads every workflow with a YAML parser and annotates the offending file. It would have caught this at PR time.

## Not a production regression

Production has been healthy throughout and is serving `ba97fd6`, which **contains #120's Go module security bumps** — those landed on the successful 20:08 deploy. These two failures were the workflow file, not the deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EdAzmVtvNSJHgwbKHsiMu