### PR TITLE
feat(agentd): register a work as text with pictures in it

### DIFF
--- a/docs/design/editor-integration-spec.md
+++ b/docs/design/editor-integration-spec.md
@@ -212,6 +212,44 @@ exists to preserve. The agent commits all observations in a window to the leaf a
 over the sequence, so a leaf carries each one intact and a holder can later disclose one without
 the others. See `wire-format.md` §3.
 
+### `POST /v1/part?session=…`
+
+Add one part to a work made of text and pictures — a novel with a figure in it, a manuscript with
+a screenshot, a graphic novel at the extreme.
+
+**The body is the part's raw bytes, not JSON.** There is no envelope and no field name:
+
+```
+POST /v1/part?session=s_01J… HTTP/1.1
+Content-Length: 84213
+
+<the bytes>
+```
+
+```jsonc
+// response
+{ "part": "sha256:…",     // part_commit of these bytes
+  "index": 1,             // where it sits, zero-based
+  "parts_total": 2 }
+```
+
+**Why not base64 in the JSON body.** A JSON string is a sequence of Unicode scalar values, so a
+PNG has to be encoded to survive it. Base64 inflates by a third, and against the fixed 64 MiB body
+limit that puts the real ceiling at 48 MiB — right in the middle of ordinary raw photo sizes, so
+some frames from a camera fit and others do not. A limit that depends on an encoding the caller
+never chose is a limit nobody can predict.
+
+**The agent keeps 32 bytes and drops the rest.** Each part is committed to as it arrives, so the
+body limit applies to a single *part* rather than to the work. Three hundred pages of artwork is
+under ten kilobytes of session state, and the size of a registrable work stops being a property of
+the daemon's memory.
+
+**Order is the order of calls, and it is committed.** An editor that wants a different order sends
+the parts in that order. See `wire-format.md` §6 for what the ordering commits to.
+
+Parts belong to the revision that commits them: after `commit` the pending list is empty, and the
+next revision starts from nothing.
+
 ### `POST /v1/commit`
 
 Request that accumulated observations become a revision leaf.
@@ -220,6 +258,7 @@ Request that accumulated observations become a revision leaf.
 // request
 { "session": "s_01J…",
   "content": "…",              // full buffer; committed as SHA256(0x03‖bytes)
+                               // omit entirely when the work was sent as parts
   "reason":  "idle" }          // | save | close | explicit
 
 // response — committed
@@ -236,6 +275,10 @@ Request that accumulated observations become a revision leaf.
 
 **`commit` is a request, not a command.** The agent may coalesce, defer, or refuse it. An editor
 that treats a non-commit as an error is misreading the contract — §4 covers why.
+
+**Send `content` or parts, never both.** They commit to different roots, either could plausibly be
+what the caller meant, and guessing would silently register a work the creator did not describe.
+The agent answers `400 ambiguous_content` rather than choosing.
 
 ### `GET /v1/entity/{id}/proof?seq=N`
 

--- a/provenance/README.md
+++ b/provenance/README.md
@@ -225,7 +225,8 @@ Honest status, because the crate docs describe intent and this describes reality
 | Calendar client, against a real calendar | **Verified.** `net/tests/live_calendar.rs`, `#[ignore]`d — run it with `-- --ignored` |
 | DAON verifying a submitted proof | **Works.** The API loads the `wasm32` build. Rebuild it with `./scripts/build-verifier-wasm.sh --install`; CI fails if the committed copy drifts |
 | Storing content | **Off by default.** Segments were write-only, and a fixed 1 KiB boundary makes a revision pass cost a full copy of the document. `open_keeping_content` opts in |
-| **Binary and image registration** | **Missing.** Text only |
+| Composite works: text with images | **Works.** `POST /v1/part` streams a work past the agent one part at a time; the agent keeps 32 bytes per part. `wire-format.md` §6 |
+| **Standalone binary registration** | **Not a separate feature.** A lone image is a one-part work |
 
 A chain can now be written, batched, submitted, upgraded and verified end to end.
 

--- a/provenance/agent/src/lib.rs
+++ b/provenance/agent/src/lib.rs
@@ -32,8 +32,8 @@ pub mod policy;
 pub mod witness;
 
 use daon_provenance_core::{
-    content_commit, inclusion_proof, merkle_root, meta_commit, tag, Beacon, Hash, Observation,
-    ProofStep, RevisionLeaf, SEGMENT_SIZE,
+    content_commit, content_commit_parts, inclusion_proof, merkle_root, meta_commit, part_commit,
+    tag, Beacon, Hash, Observation, ProofStep, RevisionLeaf, SEGMENT_SIZE,
 };
 use std::fs;
 use std::io::Write;
@@ -349,6 +349,49 @@ impl Store {
         Ok((self.leaf(entity, seq)?, inclusion_proof(&ids, seq as usize)))
     }
 
+    /// Commit to one part of a composite work, returning its [`part_commit`].
+    ///
+    /// The caller keeps 32 bytes and may drop the part's bytes immediately. That
+    /// is the whole point: a work is registered by streaming its parts past the
+    /// agent one at a time, so the agent's memory is 32 bytes per part rather
+    /// than the size of the work. Three hundred pages of artwork is under ten
+    /// kilobytes of state.
+    ///
+    /// Storage follows the same rule as [`Store::put_content`] — off unless the
+    /// store was opened with [`Store::open_keeping_content`].
+    pub fn put_part(&self, part: &[u8]) -> Result<Hash, Error> {
+        self.put_content(part)?;
+        Ok(part_commit(part))
+    }
+
+    /// Append a revision whose content is an ordered sequence of parts.
+    ///
+    /// For the in-memory case: a novel with a figure in it, where holding the
+    /// whole work at once is unremarkable. Large works should stream through
+    /// [`Store::put_part`] and finish with [`Store::append_commit`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn append_parts(
+        &self,
+        entity: Option<&Hash>,
+        parts: &[&[u8]],
+        observations: &[Observation],
+        beacon: Beacon,
+        signer: &dyn Signer,
+        local_time_ms: i64,
+    ) -> Result<(Hash, StoredLeaf), Error> {
+        for p in parts {
+            self.put_content(p)?;
+        }
+        self.append_commit(
+            entity,
+            content_commit_parts(parts),
+            observations,
+            beacon,
+            signer,
+            local_time_ms,
+        )
+    }
+
     /// Append a revision.
     ///
     /// For `seq` 0 this creates the entity, whose id is the genesis leaf id —
@@ -363,10 +406,34 @@ impl Store {
         signer: &dyn Signer,
         local_time_ms: i64,
     ) -> Result<(Hash, StoredLeaf), Error> {
+        let cc = self.put_content(content)?;
+        self.append_commit(entity, cc, observations, beacon, signer, local_time_ms)
+    }
+
+    /// Append a revision from an already-computed content commitment.
+    ///
+    /// The shared tail of [`Store::append`] and [`Store::append_parts`], and the
+    /// entry point for a caller that streamed parts and holds only their
+    /// [`part_commit`] hashes — fold those with
+    /// [`daon_provenance_core::merkle_root`] and pass the result.
+    ///
+    /// Takes 32 bytes rather than content on purpose. A store that insisted on
+    /// seeing the bytes could not register a work larger than memory, and would
+    /// make the size of a work a property of the implementation rather than of
+    /// the format.
+    #[allow(clippy::too_many_arguments)]
+    pub fn append_commit(
+        &self,
+        entity: Option<&Hash>,
+        cc: Hash,
+        observations: &[Observation],
+        beacon: Beacon,
+        signer: &dyn Signer,
+        local_time_ms: i64,
+    ) -> Result<(Hash, StoredLeaf), Error> {
         if observations.is_empty() {
             return Err(Error::NoObservations);
         }
-        let cc = self.put_content(content)?;
         let mc = meta_commit(observations).map_err(|_| Error::NoObservations)?;
 
         let (seq, parent_head) = match entity {

--- a/provenance/agentd/src/api.rs
+++ b/provenance/agentd/src/api.rs
@@ -76,6 +76,14 @@ struct Live {
     entity: Option<Hash>,
     tool_id: Vec<u8>,
     policy: Session,
+    /// `part_commit` of each part accepted so far, in order.
+    ///
+    /// Hashes, never bytes. A work is streamed past the agent one part at a
+    /// time and each part is dropped as soon as it is committed to, so this
+    /// costs 32 bytes per part: a three-hundred-page graphic novel is under ten
+    /// kilobytes of session state, and the size of a registrable work stops
+    /// being a property of the daemon's memory.
+    parts: Vec<Hash>,
 }
 
 impl Agent {
@@ -103,6 +111,7 @@ impl Agent {
         match (req.method.as_str(), req.path.as_str()) {
             ("POST", "/v1/session/open") => self.session_open(req, now_ms),
             ("POST", "/v1/observe") => self.observe(req, now_ms),
+            ("POST", "/v1/part") => self.part(req),
             ("POST", "/v1/commit") => self.commit(req, now_ms),
             ("GET", p) if p.starts_with("/v1/entity/") && p.ends_with("/proof") => {
                 self.proof(req, p)
@@ -186,6 +195,7 @@ impl Agent {
                 entity,
                 tool_id: body.tool_id.clone().into_bytes(),
                 policy,
+                parts: Vec::new(),
             },
         );
 
@@ -269,6 +279,9 @@ impl Agent {
 #[derive(Deserialize)]
 struct CommitReq {
     session: String,
+    /// Absent when the work was streamed as parts, which is the whole point of
+    /// `/v1/part`: a composite has no single buffer to put here.
+    #[serde(default)]
     content: String,
     reason: String,
 }
@@ -289,7 +302,58 @@ struct NotCommitted {
     retry_after_ms: u64,
 }
 
+/// What accepting one part produced.
+#[derive(Serialize)]
+struct PartAccepted {
+    part: String,
+    index: usize,
+    parts_total: usize,
+}
+
 impl Agent {
+    /// `POST /v1/part?session=…` — add one part to the work being assembled.
+    ///
+    /// The body is the part's raw bytes, not JSON. **JSON cannot carry a PNG**:
+    /// a JSON string is a sequence of Unicode scalar values, so arbitrary bytes
+    /// must be escaped or encoded to survive it. Base64 was the obvious
+    /// alternative and does not fit — it inflates by a third, so against the
+    /// fixed 64 MiB [`MAX_BODY`](crate::http::MAX_BODY) the real ceiling would be
+    /// 48 MiB, and a limit that depends on an encoding the caller never chose is
+    /// a limit nobody can predict.
+    ///
+    /// The agent commits to the bytes and drops them. What it keeps is 32 bytes,
+    /// so the ceiling applies to a single *part* rather than to the work: a
+    /// novel with three figures, or three hundred pages of artwork, are the same
+    /// problem at different scales.
+    ///
+    /// Order is the order of calls, and it is committed — see `wire-format.md`
+    /// §6. An editor that wants a different order sends the parts in it.
+    fn part(&self, req: &Request) -> Reply {
+        let Some(session) = req.query.get("session") else {
+            return Reply::err(400, "missing_session", "expected ?session=s_…");
+        };
+
+        let mut inner = self.inner.lock().unwrap();
+        let Inner {
+            store, sessions, ..
+        } = &mut *inner;
+        let Some(live) = sessions.get_mut(session) else {
+            return Reply::err(404, "unknown_session", "no such session");
+        };
+
+        let commit = match store.put_part(&req.body) {
+            Ok(h) => h,
+            Err(e) => return Reply::err(500, "part_failed", &e.to_string()),
+        };
+        live.parts.push(commit);
+
+        Reply::ok(&PartAccepted {
+            part: hex_id(&commit),
+            index: live.parts.len() - 1,
+            parts_total: live.parts.len(),
+        })
+    }
+
     fn commit(&self, req: &Request, now_ms: i64) -> Reply {
         let body: CommitReq = match parse(&req.body) {
             Ok(b) => b,
@@ -303,6 +367,17 @@ impl Agent {
         let Some(live) = inner.sessions.get_mut(&body.session) else {
             return Reply::err(404, "unknown_session", "no such session");
         };
+
+        // Both at once is refused rather than resolved. Either could plausibly
+        // be what the caller meant, they commit to different roots, and guessing
+        // would silently register a work the creator did not describe.
+        if !live.parts.is_empty() && !body.content.is_empty() {
+            return Reply::err(
+                400,
+                "ambiguous_content",
+                "sent parts and content; commit one or the other",
+            );
+        }
 
         match live.policy.decide(reason, now_ms) {
             Decision::Commit => {}
@@ -338,6 +413,11 @@ impl Agent {
         let entity = live.entity;
         let tool = live.tool_id.clone();
         let _ = tool;
+        // Taken, not borrowed: a committed part belongs to the revision that
+        // committed it. Leaving them would silently fold this revision's parts
+        // into the next one, which is the kind of bug that only shows up as a
+        // wrong hash months later.
+        let parts = std::mem::take(&mut live.parts);
 
         // The beacon is a free lower bound on time, taken from a recent Bitcoin
         // block. Until the daemon has a block source this is the zero beacon,
@@ -357,14 +437,27 @@ impl Agent {
             ..
         } = &mut *inner;
 
-        let appended = store.append(
-            entity.as_ref(),
-            body.content.as_bytes(),
-            &observations,
-            beacon,
-            signer.as_ref(),
-            now_ms,
-        );
+        // A composite finishes from the part hashes alone -- the bytes were
+        // dropped as each part arrived, which is what lets a work exceed memory.
+        let appended = if parts.is_empty() {
+            store.append(
+                entity.as_ref(),
+                body.content.as_bytes(),
+                &observations,
+                beacon,
+                signer.as_ref(),
+                now_ms,
+            )
+        } else {
+            store.append_commit(
+                entity.as_ref(),
+                daon_provenance_core::merkle_root(&parts),
+                &observations,
+                beacon,
+                signer.as_ref(),
+                now_ms,
+            )
+        };
 
         let (entity_id, leaf) = match appended {
             Ok(v) => v,

--- a/provenance/agentd/tests/parts.rs
+++ b/provenance/agentd/tests/parts.rs
@@ -1,0 +1,325 @@
+//! Registering a work that is text with pictures in it.
+//!
+//! `POST /v1/part` streams the work past the agent one part at a time. The agent
+//! keeps 32 bytes per part and drops the bytes, so what these tests are really
+//! about is that the leaf ends up committing to exactly the parts that were sent,
+//! in the order they were sent, without the daemon ever holding the whole work.
+
+use daon_provenance_agent::policy::Limits;
+use daon_provenance_agent::witness::WitnessLog;
+use daon_provenance_agent::{Signer, Store};
+use daon_provenance_agentd::api::Agent;
+use daon_provenance_agentd::http::Request;
+use daon_provenance_core::{content_commit_parts, Hash, RevisionLeaf};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+struct TestSigner;
+impl Signer for TestSigner {
+    fn author_key(&self) -> Hash {
+        [0xa1; 32]
+    }
+    fn recovery_key(&self) -> Hash {
+        [0xb2; 32]
+    }
+    fn sign(&self, _leaf_id: &Hash) -> [u8; 64] {
+        [0xcc; 64]
+    }
+}
+
+fn agent() -> (TempDir, Agent) {
+    let dir = TempDir::new().unwrap();
+    let store = Store::open(dir.path()).unwrap();
+    let witness = std::sync::Arc::new(WitnessLog::open(dir.path()).unwrap());
+    (
+        dir,
+        Agent::new(store, witness, Box::new(TestSigner), Limits::default()),
+    )
+}
+
+fn post(agent: &Agent, path: &str, body: Value, now_ms: i64) -> (u16, Value) {
+    raw_post(agent, path, body.to_string().as_bytes(), now_ms)
+}
+
+/// A request whose body is bytes rather than JSON — the point of `/v1/part`.
+fn raw_post(agent: &Agent, path: &str, body: &[u8], now_ms: i64) -> (u16, Value) {
+    let mut req = format!(
+        "POST {path} HTTP/1.1\r\nContent-Length: {}\r\n\r\n",
+        body.len()
+    )
+    .into_bytes();
+    req.extend_from_slice(body);
+    let parsed = Request::read(&req[..]).expect("request parses");
+    let reply = agent.handle(&parsed, now_ms);
+    (
+        reply.status,
+        serde_json::from_slice(&reply.body).unwrap_or(Value::Null),
+    )
+}
+
+fn open_session(agent: &Agent, now_ms: i64) -> String {
+    let (s, b) = post(
+        agent,
+        "/v1/session/open",
+        json!({"tool_id": "test-editor/1.0"}),
+        now_ms,
+    );
+    assert_eq!(s, 200, "{b}");
+    b["session"].as_str().unwrap().to_string()
+}
+
+fn observe(agent: &Agent, session: &str, now_ms: i64) {
+    let (s, b) = post(
+        agent,
+        "/v1/observe",
+        json!({"session": session, "ingress": "keystroke_stream",
+               "span_bytes": {"added": 120, "removed": 4},
+               "op_count": 40, "duration_ms": 30000}),
+        now_ms,
+    );
+    assert_eq!(s, 200, "{b}");
+}
+
+/// A PNG header and some bytes: not valid UTF-8, which is the thing a JSON
+/// string could not have carried.
+fn png(seed: u8, len: usize) -> Vec<u8> {
+    let mut v = vec![0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+    v.extend((0..len).map(|i| seed.wrapping_add((i * 37) as u8)));
+    v
+}
+
+#[test]
+fn a_work_of_text_and_pictures_commits_to_exactly_those_parts() {
+    let (_d, agent) = agent();
+    let s = open_session(&agent, 1_000);
+    observe(&agent, &s, 1_000);
+
+    let page = b"The lighthouse keeper wrote this by hand.".to_vec();
+    let figure = png(7, 5000);
+    let after = b"And then the storm came in.".to_vec();
+
+    for (i, part) in [&page, &figure, &after].iter().enumerate() {
+        let (status, body) = raw_post(&agent, &format!("/v1/part?session={s}"), part, 1_000);
+        assert_eq!(status, 200, "{body}");
+        assert_eq!(body["index"].as_u64().unwrap() as usize, i);
+        assert_eq!(body["parts_total"].as_u64().unwrap() as usize, i + 1);
+    }
+
+    let (status, body) = post(
+        &agent,
+        "/v1/commit",
+        json!({"session": s, "reason": "explicit"}),
+        1_000,
+    );
+    assert_eq!(status, 200, "{body}");
+    assert_eq!(body["committed"], true);
+
+    // The leaf must carry the composite root, not something merely plausible.
+    let entity = body["entity_id"].as_str().unwrap().to_string();
+    let (status, proof) = {
+        let req = format!("GET /v1/entity/{entity}/proof?seq=0 HTTP/1.1\r\n\r\n");
+        let parsed = Request::read(req.as_bytes()).unwrap();
+        let reply = agent.handle(&parsed, 1_000);
+        (
+            reply.status,
+            serde_json::from_slice::<Value>(&reply.body).unwrap(),
+        )
+    };
+    assert_eq!(status, 200, "{proof}");
+
+    let leaf_hex = proof["leaf"].as_str().unwrap();
+    let leaf_bytes = hex::decode(leaf_hex).unwrap();
+    let leaf = RevisionLeaf::decode(&leaf_bytes).expect("leaf decodes");
+
+    let expected: Vec<&[u8]> = vec![&page, &figure, &after];
+    assert_eq!(
+        leaf.content_commit,
+        content_commit_parts(&expected),
+        "the leaf must commit to the parts that were sent, in order"
+    );
+}
+
+#[test]
+fn order_is_the_order_of_calls() {
+    let a = b"alpha".to_vec();
+    let b = png(3, 900);
+
+    let root_of = |order: [&Vec<u8>; 2]| {
+        let (_d, agent) = agent();
+        let s = open_session(&agent, 1_000);
+        observe(&agent, &s, 1_000);
+        for p in order {
+            raw_post(&agent, &format!("/v1/part?session={s}"), p, 1_000);
+        }
+        let (_, body) = post(
+            &agent,
+            "/v1/commit",
+            json!({"session": s, "reason": "explicit"}),
+            1_000,
+        );
+        let entity = body["entity_id"].as_str().unwrap().to_string();
+        let req = format!("GET /v1/entity/{entity}/proof?seq=0 HTTP/1.1\r\n\r\n");
+        let parsed = Request::read(req.as_bytes()).unwrap();
+        let reply = agent.handle(&parsed, 1_000);
+        let v: Value = serde_json::from_slice(&reply.body).unwrap();
+        let leaf =
+            RevisionLeaf::decode(&hex::decode(v["leaf"].as_str().unwrap()).unwrap()).unwrap();
+        leaf.content_commit
+    };
+
+    assert_ne!(root_of([&a, &b]), root_of([&b, &a]));
+}
+
+#[test]
+fn parts_belong_to_the_revision_that_committed_them() {
+    let (_d, agent) = agent();
+    let s = open_session(&agent, 1_000);
+
+    observe(&agent, &s, 1_000);
+    let first = png(1, 700);
+    raw_post(&agent, &format!("/v1/part?session={s}"), &first, 1_000);
+    let (_, r1) = post(
+        &agent,
+        "/v1/commit",
+        json!({"session": s, "reason": "explicit"}),
+        1_000,
+    );
+    assert_eq!(r1["committed"], true);
+
+    // A second revision sending one part must commit to *that* part alone. If
+    // the first revision's parts leaked forward, this root would cover two.
+    observe(&agent, &s, 60_000);
+    let second = png(2, 700);
+    let (status, body) = raw_post(&agent, &format!("/v1/part?session={s}"), &second, 60_000);
+    assert_eq!(status, 200, "{body}");
+    assert_eq!(
+        body["parts_total"].as_u64().unwrap(),
+        1,
+        "the previous revision's parts must not still be pending"
+    );
+
+    let (_, r2) = post(
+        &agent,
+        "/v1/commit",
+        json!({"session": s, "reason": "explicit"}),
+        60_000,
+    );
+    assert_eq!(r2["committed"], true);
+
+    let entity = r2["entity_id"].as_str().unwrap().to_string();
+    let req = format!("GET /v1/entity/{entity}/proof?seq=1 HTTP/1.1\r\n\r\n");
+    let parsed = Request::read(req.as_bytes()).unwrap();
+    let v: Value = serde_json::from_slice(&agent.handle(&parsed, 60_000).body).unwrap();
+    let leaf = RevisionLeaf::decode(&hex::decode(v["leaf"].as_str().unwrap()).unwrap()).unwrap();
+
+    let only_second: Vec<&[u8]> = vec![&second];
+    assert_eq!(leaf.content_commit, content_commit_parts(&only_second));
+}
+
+#[test]
+fn sending_both_parts_and_content_is_refused_rather_than_guessed() {
+    let (_d, agent) = agent();
+    let s = open_session(&agent, 1_000);
+    observe(&agent, &s, 1_000);
+    raw_post(&agent, &format!("/v1/part?session={s}"), b"a part", 1_000);
+
+    let (status, body) = post(
+        &agent,
+        "/v1/commit",
+        json!({"session": s, "content": "and a buffer", "reason": "explicit"}),
+        1_000,
+    );
+    assert_eq!(status, 400, "{body}");
+    assert_eq!(body["error"], "ambiguous_content");
+}
+
+#[test]
+fn a_part_needs_a_known_session() {
+    let (_d, agent) = agent();
+    let (status, body) = raw_post(&agent, "/v1/part?session=s_00000000deadbeef", b"x", 1_000);
+    assert_eq!(status, 404, "{body}");
+    assert_eq!(body["error"], "unknown_session");
+
+    let (status, body) = raw_post(&agent, "/v1/part", b"x", 1_000);
+    assert_eq!(status, 400, "{body}");
+    assert_eq!(body["error"], "missing_session");
+}
+
+#[test]
+fn a_plain_text_commit_still_works_exactly_as_before() {
+    let (_d, agent) = agent();
+    let s = open_session(&agent, 1_000);
+    observe(&agent, &s, 1_000);
+
+    let (status, body) = post(
+        &agent,
+        "/v1/commit",
+        json!({"session": s, "content": "just prose", "reason": "explicit"}),
+        1_000,
+    );
+    assert_eq!(status, 200, "{body}");
+
+    let entity = body["entity_id"].as_str().unwrap().to_string();
+    let req = format!("GET /v1/entity/{entity}/proof?seq=0 HTTP/1.1\r\n\r\n");
+    let parsed = Request::read(req.as_bytes()).unwrap();
+    let v: Value = serde_json::from_slice(&agent.handle(&parsed, 1_000).body).unwrap();
+    let leaf = RevisionLeaf::decode(&hex::decode(v["leaf"].as_str().unwrap()).unwrap()).unwrap();
+
+    assert_eq!(
+        leaf.content_commit,
+        daon_provenance_core::content_commit(b"just prose"),
+        "a work with no parts must still commit flat, not as a one-part composite"
+    );
+}
+
+/// The memory claim, made checkable: the daemon's state for a work is 32 bytes
+/// per part regardless of how large the parts are.
+#[test]
+fn the_agent_does_not_retain_the_bytes() {
+    let (dir, agent) = agent();
+    let s = open_session(&agent, 1_000);
+    observe(&agent, &s, 1_000);
+
+    // Four megabytes of parts through a store that does not keep content.
+    for i in 0..4u8 {
+        let big = png(i, 1024 * 1024);
+        let (status, _) = raw_post(&agent, &format!("/v1/part?session={s}"), &big, 1_000);
+        assert_eq!(status, 200);
+    }
+    post(
+        &agent,
+        "/v1/commit",
+        json!({"session": s, "reason": "explicit"}),
+        1_000,
+    );
+
+    // Nothing resembling the content reached the disk: leaves and signatures
+    // only, 218 + 64 bytes per revision.
+    let mut total = 0u64;
+    for e in walkdir(dir.path()) {
+        total += std::fs::metadata(&e).map(|m| m.len()).unwrap_or(0);
+    }
+    assert!(
+        total < 64 * 1024,
+        "store grew to {total} bytes for 4 MiB of parts -- content is being kept"
+    );
+}
+
+fn walkdir(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&d) else {
+            continue;
+        };
+        for e in rd.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                stack.push(p);
+            } else {
+                out.push(p);
+            }
+        }
+    }
+    out
+}


### PR DESCRIPTION
#134 gave the format a way to commit a composite work. **Nothing could produce one** — `Store::append` took `&[u8]` and `/v1/commit` took a JSON string, so a PNG could not reach either.

```
POST /v1/part?session=…    body is the part's raw bytes, not JSON
                           → { part, index, parts_total }
POST /v1/commit            omit `content`; the parts become the revision
```

## Raw bytes, not base64

A JSON string is a sequence of Unicode scalar values, so arbitrary bytes must be encoded to survive it. Base64 inflates by a third — against the fixed 64 MiB body limit that puts the real ceiling at **48 MiB**, which lands in the middle of ordinary raw photo sizes. Some frames from one camera would fit and others wouldn't, for reasons invisible to the caller.

## 32 bytes per part

The agent commits to each part as it arrives and drops the bytes, so the limit applies to a *part* rather than to the work. Three hundred pages of artwork is under ten kilobytes of session state.

That claim is checked, not described — `the_agent_does_not_retain_the_bytes` pushes 4 MiB of parts through and asserts the store stays under 64 KiB.

## Store

`put_part` and `append_commit`. The latter takes an already-computed content commitment because a store that insisted on seeing the bytes couldn't register a work larger than memory — that would make the size of a registrable work a property of *this implementation* rather than of the format.

## Three decisions worth flagging

- **Parts are taken, not borrowed, at commit.** A committed part belongs to the revision that committed it. Leaving them would fold this revision's parts into the next — a bug that surfaces months later as a wrong hash and nothing else.
- **`content` + parts together is `400 ambiguous_content`**, not resolved. They commit to different roots, either could be what the caller meant, and guessing would silently register a work the creator did not describe.
- **A work with no parts still commits flat.** A lone image is a one-part work; a plain manuscript is not. The format already distinguishes these and the ingress preserves that.

## Verification

7 new tests — round trip through the real store and the proof route, order sensitivity, revision isolation, the ambiguity refusal, unchanged plain-text behaviour, and the memory claim. Whole suite **170 passed**, clippy clean, wasm unchanged.

Spec updated: `editor-integration-spec.md` §3 carries the new route and the send-one-or-the-other rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EdAzmVtvNSJHgwbKHsiMu