### PR TITLE
feat(2fa): tell people their iPhone already does this

### DIFF
--- a/daon-frontend/components/auth/AuthenticatorGuide.tsx
+++ b/daon-frontend/components/auth/AuthenticatorGuide.tsx
@@ -15,7 +15,7 @@ interface AuthenticatorGuideProps {
   onClose: () => void;
 }
 
-type AuthApp = 'google' | 'authy' | '1password' | 'microsoft' | 'bitwarden';
+type AuthApp = 'apple' | 'google' | 'authy' | '1password' | 'microsoft' | 'bitwarden';
 
 interface AppGuide {
   name: string;
@@ -31,6 +31,23 @@ interface AppGuide {
 }
 
 const AUTHENTICATOR_APPS: Record<AuthApp, AppGuide> = {
+  // First, because it is the only option that needs no download at all. Every
+  // other entry here starts with "go to a store and install something", which is
+  // the step people abandon -- and roughly half of them are holding a device
+  // that has had this built in since iOS 15.
+  apple: {
+    name: 'iPhone or Mac (built in)',
+    iconColor: 'text-gray-700',
+    platforms: ['iOS', 'macOS'],
+    steps: [
+      'Nothing to install -- this is already on your device',
+      'Open Settings (iPhone) or System Settings \u2192 Passwords (Mac)',
+      'Find or create the entry for DAON, then tap "Set Up Verification Code"',
+      'Choose "Scan QR Code" and point your camera at the code on this page',
+      'Enter the 6-digit code it shows to complete setup'
+    ],
+    downloadLinks: {}
+  },
   google: {
     name: 'Google Authenticator',
     iconColor: 'text-blue-500',

--- a/daon-frontend/components/auth/TwoFactorSetup.tsx
+++ b/daon-frontend/components/auth/TwoFactorSetup.tsx
@@ -307,6 +307,25 @@ export function TwoFactorSetup({ tempSessionId, onSuccess, onError }: TwoFactorS
         {/* Authenticator Guide Modal */}
         <AuthenticatorGuide isOpen={showGuide} onClose={() => setShowGuide(false)} />
 
+        {/*
+          The longer written guide existed but nothing in this flow linked to it,
+          so the only help available at the moment of confusion was the modal
+          above. Someone standing at a QR code wondering what to install had no
+          way to reach it.
+        */}
+        <p className="text-sm text-gray-500 text-center">
+          On an iPhone or Mac you don&apos;t need to install anything &mdash; verification
+          codes are built into Settings &rarr; Passwords.{' '}
+          <a
+            href="https://daon.network/get-started/2fa-setup/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 hover:underline"
+          >
+            Full setup guide
+          </a>
+        </p>
+
         {/* Step 2: Verify */}
         <div className="border border-gray-200 rounded-xl p-6 space-y-4">
           <div className="flex items-center space-x-2">

--- a/docs/get-started/2fa-setup.md
+++ b/docs/get-started/2fa-setup.md
@@ -28,6 +28,31 @@ Even if someone discovers your password, they cannot access your account without
 
 ## Choose Your Authenticator App
 
+### On an iPhone or Mac, you already have one
+
+**Platforms:** iOS 15+, macOS Monterey+
+**Best for:** anyone on Apple hardware — there is nothing to download
+
+Apple builds verification codes into the Passwords settings. Most people don't
+know this and go install a separate app they didn't need.
+
+1. **iPhone:** Settings → Passwords. **Mac:** System Settings → Passwords
+2. Find or create the entry for DAON
+3. Tap **Set Up Verification Code** → **Scan QR Code**
+4. Point the camera at the QR code on the DAON setup page
+5. Enter the 6-digit code it shows
+
+Codes then appear alongside your saved password and sync across your devices
+through iCloud Keychain, so a new phone doesn't mean setting 2FA up again.
+
+> **One caveat worth knowing.** If your DAON password *and* your verification
+> codes both live in the same Apple Passwords entry, anyone who gets into your
+> Apple account has both factors. That is a real tradeoff for convenience. If
+> you want the factors genuinely separate, use a dedicated app below and keep it
+> on one device.
+
+---
+
 Select from one of these popular authenticator apps:
 
 ### Google Authenticator

--- a/documentation/operations/INCOMPLETE_SIGNUP_EMAIL.md
+++ b/documentation/operations/INCOMPLETE_SIGNUP_EMAIL.md
@@ -24,15 +24,18 @@ rather than a request for their attention.
 >
 > You started setting up a DAON account and didn't get past the two-factor step.
 >
-> That step asks you to install an authenticator app, and it only gave you five
+> That step asks you to set up an authenticator, and it only gave you five
 > minutes to do it. That was too short. It's thirty now.
 >
 > If you'd like to pick it up: **[Finish setting up →]**
 >
-> It goes faster if you have an authenticator app ready first — Aegis, Ente
-> Auth, 1Password, Bitwarden, Google Authenticator, any of them. Two-factor is
-> required on every DAON account, because the account holds ownership records
-> for your work and we'd rather not make those easy to steal.
+> **If you have an iPhone or a Mac, you don't need to install anything** — it's
+> already built in. Settings → Passwords → tap the entry → *Set Up Verification
+> Code*. On Android or a PC, any authenticator works: Aegis, Ente Auth,
+> 1Password, Bitwarden, Google Authenticator.
+>
+> Two-factor is required on every DAON account, because the account holds
+> ownership records for your work and we'd rather not make those easy to steal.
 >
 > If you'd rather not, that's genuinely fine: **[delete my account and data]**.
 >
@@ -47,7 +50,8 @@ rather than a request for their attention.
 | "that was our fault" in the subject | It was. Leading with it means they know within one line that this isn't a nudge. |
 | No date, no timings, no "we noticed" | Nothing that reveals what the logs hold. |
 | The fix is stated before the ask | They learn something true whether or not they click. |
-| App names listed | The thing that blocked them was not knowing what they needed. Naming options removes the research step. |
+| Apple's built-in option first | It is the one that needs no install at all, and most people don't know their phone already does this. The barrier was never unwillingness — it was standing at a QR code wondering what to go download. Removing the download removes the barrier. |
+| Other app names listed after | For everyone not on Apple, naming options removes the research step. |
 | Why 2FA is mandatory, in one clause | Answers the obvious objection without arguing. |
 | Delete link as prominent as the resume link | If the answer is no, make no easy. An escape hatch that is hard to find is a dark pattern. |
 | "the only message of this kind" | A promise, and it should be kept. |

--- a/documentation/operations/INCOMPLETE_SIGNUP_EMAIL.md
+++ b/documentation/operations/INCOMPLETE_SIGNUP_EMAIL.md
@@ -1,0 +1,76 @@
+# Reaching someone whose signup didn't finish
+
+**Status:** drafted, not sent. Sending is a human decision.
+
+## The rule this follows
+
+One message, about a thing they started, that they can act on or ignore. Not a
+sequence. Not a reminder. Not a second one if they don't reply.
+
+**Never say what you observed.** The line between a useful email and a creepy one
+is almost entirely this. "You spent four minutes on the setup screen" is
+surveillance. "Your setup didn't finish" is a fact about their account, which
+they already know and can verify.
+
+**Have a reason that isn't "please come back."** If nothing changed, there is
+nothing to say and the honest move is silence. Here something did change: the
+setup window was five minutes and is now thirty, because five was too short. That
+is a real update. It also means the email is an apology with a fix attached
+rather than a request for their attention.
+
+## Draft
+
+> **Subject:** Your DAON setup didn't finish — that was our fault
+>
+> You started setting up a DAON account and didn't get past the two-factor step.
+>
+> That step asks you to install an authenticator app, and it only gave you five
+> minutes to do it. That was too short. It's thirty now.
+>
+> If you'd like to pick it up: **[Finish setting up →]**
+>
+> It goes faster if you have an authenticator app ready first — Aegis, Ente
+> Auth, 1Password, Bitwarden, Google Authenticator, any of them. Two-factor is
+> required on every DAON account, because the account holds ownership records
+> for your work and we'd rather not make those easy to steal.
+>
+> If you'd rather not, that's genuinely fine: **[delete my account and data]**.
+>
+> Either way this is the only message of this kind you'll get.
+>
+> — DAON
+
+## Why it is worded that way
+
+| Choice | Reason |
+| --- | --- |
+| "that was our fault" in the subject | It was. Leading with it means they know within one line that this isn't a nudge. |
+| No date, no timings, no "we noticed" | Nothing that reveals what the logs hold. |
+| The fix is stated before the ask | They learn something true whether or not they click. |
+| App names listed | The thing that blocked them was not knowing what they needed. Naming options removes the research step. |
+| Why 2FA is mandatory, in one clause | Answers the obvious objection without arguing. |
+| Delete link as prominent as the resume link | If the answer is no, make no easy. An escape hatch that is hard to find is a dark pattern. |
+| "the only message of this kind" | A promise, and it should be kept. |
+
+## What not to do
+
+- No follow-up if they don't respond
+- No "we noticed you haven't..." phrasing anywhere
+- No discount, urgency, or scarcity framing — there is nothing to sell
+- Do not send to anyone who did not start a signup themselves
+
+## Who qualifies right now
+
+One person. Query:
+
+```sql
+SELECT u.id, u.email
+FROM users u
+JOIN temp_sessions ts ON ts.user_id = u.id
+WHERE ts.completed_at IS NULL
+  AND u.totp_enabled = false
+  AND ts.flow_type = '2fa_setup';
+```
+
+If this ever returns more than a handful, the answer is not to send more email —
+it is that signup is broken and needs fixing first.

--- a/documentation/operations/SSH_HARDENING.md
+++ b/documentation/operations/SSH_HARDENING.md
@@ -1,0 +1,74 @@
+# SSH hardening
+
+**Status:** applied 21 August 2026 · **Host:** `api.daon.network` (Hetzner)
+
+## What changed
+
+Password authentication is off. Keys only.
+
+`/etc/ssh/sshd_config.d/10-daon-hardening.conf`:
+
+```
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no
+PermitEmptyPasswords no
+PermitRootLogin prohibit-password
+MaxAuthTries 3
+```
+
+A drop-in rather than an edit to `sshd_config`, so a package upgrade that
+replaces the main file does not silently restore password auth. The main file
+already carries `Include /etc/ssh/sshd_config.d/*.conf`.
+
+## Why
+
+Password auth was enabled and under continuous attack:
+
+| | |
+| --- | --- |
+| Total failed attempts | 23,231 |
+| Failed in the preceding 24h | 1,586 |
+| Of those, targeting `root` | 1,027 |
+| Addresses banned by fail2ban | 3,339 |
+
+fail2ban was keeping up, but it was mopping a flood that did not need to reach
+the door. Nobody logs in with a password: both accounts with a shell — `root`
+and `deploy-bot` — use ED25519 keys, so this removed an attack surface without
+removing anyone's access.
+
+`PermitRootLogin` was `without-password`, which already prohibited passwords;
+`prohibit-password` is the same setting under a name that does not read like it
+permits something. `sshd -T` still prints `without-password` — they are synonyms.
+
+## What was verified before and after
+
+1. Both shell accounts hold an ED25519 key in `authorized_keys`
+2. The live session was authenticated by `publickey`, per the journal
+3. `sshd -t` validated the config **before** the daemon was touched
+4. `systemctl reload ssh`, not `restart` — existing sessions unaffected
+5. A **new** connection authenticated with a key afterwards
+6. A password-only attempt was refused: `Permission denied (publickey)`
+7. CI deploys with `ssh -i ~/.ssh/deploy_key`, so the pipeline is key-based
+
+Step 5 is the one that matters. Reloading leaves your current session working
+whether or not you have locked yourself out, so the change is not proven until a
+fresh connection succeeds.
+
+## Firewall
+
+`ufw` is active and correct: default deny incoming, allow outgoing, with only
+22/tcp, 80 and 443 open (v4 and v6).
+
+## fail2ban
+
+Active, one jail (`sshd`), reading the systemd journal. Expect the ban rate to
+fall now — bots that cannot offer a password fail at `publickey` instead of
+generating the auth failures the jail matches on. That is a reduction in noise,
+not in protection: the attempts can no longer succeed by guessing.
+
+## If you are locked out
+
+Hetzner's console gives root access without SSH. Remove or edit
+`/etc/ssh/sshd_config.d/10-daon-hardening.conf`, run `sshd -t`, then
+`systemctl reload ssh`.


### PR DESCRIPTION
## The gap

The docs page and the in-app guide each listed five authenticators — Google, Authy, 1Password, Microsoft, Bitwarden — and **every one starts with "go to a store and download something."**

Apple has had verification codes built into Settings → Passwords since iOS 15. Neither place mentioned it. The only `apple` strings in the codebase were App Store links.

So an iPhone user standing at the QR code was told to install an app **they were already holding.** Downloading is the step people abandon.

## What changed

- **Added first** in both the docs and the guide modal — being first is the point. By the time someone has read three entries beginning with "download", they've already gone looking for one.
- **The written guide had no route from the flow.** `docs/get-started/2fa-setup.md` existed and nothing in `TwoFactorSetup` linked to it, so the only help at the moment of confusion was the modal. Now linked — with the no-install path stated in the sentence beside it, not hidden behind the click.

## The tradeoff, stated

The docs entry says the uncomfortable part rather than only the convenience:

> If your DAON password *and* your verification codes both live in the same Apple Passwords entry, anyone who gets into your Apple account has both factors.

Anyone who wants the factors genuinely separate should use a dedicated app on one device — and should be **told** that, not discover it.

## Also

The incomplete-signup email draft (#143) told the one person it's addressed to that the step "asks you to install an app". Corrected there too.

## Verification

frontend `tsc` clean · `next build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EdAzmVtvNSJHgwbKHsiMu