### PR TITLE
docs(ops): record the SSH hardening applied to production

### DIFF
--- a/documentation/operations/SSH_HARDENING.md
+++ b/documentation/operations/SSH_HARDENING.md
@@ -1,0 +1,74 @@
+# SSH hardening
+
+**Status:** applied 21 August 2026 · **Host:** `api.daon.network` (Hetzner)
+
+## What changed
+
+Password authentication is off. Keys only.
+
+`/etc/ssh/sshd_config.d/10-daon-hardening.conf`:
+
+```
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no
+PermitEmptyPasswords no
+PermitRootLogin prohibit-password
+MaxAuthTries 3
+```
+
+A drop-in rather than an edit to `sshd_config`, so a package upgrade that
+replaces the main file does not silently restore password auth. The main file
+already carries `Include /etc/ssh/sshd_config.d/*.conf`.
+
+## Why
+
+Password auth was enabled and under continuous attack:
+
+| | |
+| --- | --- |
+| Total failed attempts | 23,231 |
+| Failed in the preceding 24h | 1,586 |
+| Of those, targeting `root` | 1,027 |
+| Addresses banned by fail2ban | 3,339 |
+
+fail2ban was keeping up, but it was mopping a flood that did not need to reach
+the door. Nobody logs in with a password: both accounts with a shell — `root`
+and `deploy-bot` — use ED25519 keys, so this removed an attack surface without
+removing anyone's access.
+
+`PermitRootLogin` was `without-password`, which already prohibited passwords;
+`prohibit-password` is the same setting under a name that does not read like it
+permits something. `sshd -T` still prints `without-password` — they are synonyms.
+
+## What was verified before and after
+
+1. Both shell accounts hold an ED25519 key in `authorized_keys`
+2. The live session was authenticated by `publickey`, per the journal
+3. `sshd -t` validated the config **before** the daemon was touched
+4. `systemctl reload ssh`, not `restart` — existing sessions unaffected
+5. A **new** connection authenticated with a key afterwards
+6. A password-only attempt was refused: `Permission denied (publickey)`
+7. CI deploys with `ssh -i ~/.ssh/deploy_key`, so the pipeline is key-based
+
+Step 5 is the one that matters. Reloading leaves your current session working
+whether or not you have locked yourself out, so the change is not proven until a
+fresh connection succeeds.
+
+## Firewall
+
+`ufw` is active and correct: default deny incoming, allow outgoing, with only
+22/tcp, 80 and 443 open (v4 and v6).
+
+## fail2ban
+
+Active, one jail (`sshd`), reading the systemd journal. Expect the ban rate to
+fall now — bots that cannot offer a password fail at `publickey` instead of
+generating the auth failures the jail matches on. That is a reduction in noise,
+not in protection: the attempts can no longer succeed by guessing.
+
+## If you are locked out
+
+Hetzner's console gives root access without SSH. Remove or edit
+`/etc/ssh/sshd_config.d/10-daon-hardening.conf`, run `sshd -t`, then
+`systemctl reload ssh`.


### PR DESCRIPTION
Password authentication was enabled on the production host and under continuous attack:

```
23,231  total failed attempts
 1,586  in the preceding 24 hours
 1,027  of those against root
 3,339  addresses banned by fail2ban keeping up
```

**Nobody logs in with a password.** Both accounts with a shell — `root` and `deploy-bot` — use ED25519 keys, so password auth was an attack surface with no user. It's now off.

Worth stating plainly for the record: **no password could ever have matched anyway.** `root` is `LOCKED` and `deploy-bot` has no password set. The attempts were guessing against accounts with nothing to guess. Closing the door was right; nothing was hanging by a thread.

## Applied

`/etc/ssh/sshd_config.d/10-daon-hardening.conf` — a drop-in rather than an edit to `sshd_config`, so a package upgrade that replaces the main file can't silently restore password auth.

```
PasswordAuthentication no
KbdInteractiveAuthentication no
ChallengeResponseAuthentication no
PermitEmptyPasswords no
PermitRootLogin prohibit-password
MaxAuthTries 3
```

## The verification order mattered more than the change

1. Both shell accounts hold an ED25519 key
2. The live session was authenticated by `publickey`, per the journal
3. `sshd -t` validated **before** the daemon was touched
4. `reload`, not `restart` — existing sessions unaffected
5. A **new** connection authenticated with a key afterwards
6. A password-only attempt was refused: `Permission denied (publickey)`
7. CI deploys with `ssh -i ~/.ssh/deploy_key`, so the pipeline is key-based

**Step 5 is the one that matters.** A reload leaves your current session working whether or not you've locked yourself out, so nothing is proven until a fresh connection succeeds.

## Already correct, unchanged

`ufw` — active, default deny incoming, only 22/80/443 open on v4 and v6.
`fail2ban` — active, `sshd` jail reading the journal.

Expect the ban rate to *fall*: bots that can't offer a password fail at `publickey` rather than generating the auth failures the jail matches on. Less noise, not less protection.

Recovery via the Hetzner console is documented, in case the door ever does get shut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EdAzmVtvNSJHgwbKHsiMu