### PR TITLE
fix: correct the SDK name and a dead host in shipped plugin code

### DIFF
--- a/integration-demos/INTEGRATION_EXAMPLES.md
+++ b/integration-demos/INTEGRATION_EXAMPLES.md
@@ -12,7 +12,7 @@
 ### 1. **Next.js Blog** (3 lines of code)
 
 ```typescript
-import { protect } from '@daon/sdk';
+import { protect } from 'daon-sdk';
 
 // Protect content when publishing
 const result = await protect(postContent, {

--- a/integration-demos/nextjs-blog/components/ProtectionBadge.tsx
+++ b/integration-demos/nextjs-blog/components/ProtectionBadge.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { verify } from '@daon/sdk';
+import { verify } from 'daon-sdk';
 
 interface ProtectionBadgeProps {
   content: string;

--- a/integration-demos/nextjs-blog/pages/api/protect.ts
+++ b/integration-demos/nextjs-blog/pages/api/protect.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { DAONClient } from '@daon/sdk';
+import { DAONClient } from 'daon-sdk';
 
 // Example API route showing how to protect content server-side
 export default async function handler(

--- a/wordpress-plugin/daon-creator-protection/includes/class-daon-client.php
+++ b/wordpress-plugin/daon-creator-protection/includes/class-daon-client.php
@@ -44,7 +44,7 @@ class DAON_Client {
                     'tx_hash' => $response['tx_hash'] ?? null,
                     'verification_url' => $response['verification_url'] ?? null,
                     'blockchain_url' => isset($response['tx_hash']) 
-                        ? "https://explorer.daon.network/tx/{$response['tx_hash']}" 
+                        ? "https://api.daon.network/api/v1/verify/{$response['tx_hash']}" 
                         : null
                 );
             } else {

--- a/wordpress-plugin/daon-creator-protection/tests/test-daon-client.php
+++ b/wordpress-plugin/daon-creator-protection/tests/test-daon-client.php
@@ -58,7 +58,7 @@ class Test_DAON_Client extends \PHPUnit\Framework\TestCase {
         $result = $this->client->protect_content('content', array(), 'liberation_v1');
 
         $this->assertSame(
-            'https://explorer.daon.network/tx/0xdeadbeef',
+            'https://api.daon.network/api/v1/verify/0xdeadbeef',
             $result['blockchain_url']
         );
     }

--- a/wordpress-plugin/daon-creator-protection/tests/test-protection-notice.php
+++ b/wordpress-plugin/daon-creator-protection/tests/test-protection-notice.php
@@ -46,7 +46,7 @@ class Test_Protection_Notice extends \PHPUnit\Framework\TestCase {
             'content_hash'     => 'sha256:abc123',
             'tx_hash'          => '0xdeadbeef',
             'verification_url' => 'https://daon.network/verify/abc123',
-            'blockchain_url'   => 'https://explorer.daon.network/tx/0xdeadbeef',
+            'blockchain_url'   => 'https://api.daon.network/api/v1/verify/0xdeadbeef',
             'license'          => 'liberation_v1',
             'protected_at'     => '2026-05-01 10:00:00',
             'verified_at'      => '2026-05-01 10:00:05',

--- a/wordpress-plugin/daon-creator-protection/tests/test-rest-api.php
+++ b/wordpress-plugin/daon-creator-protection/tests/test-rest-api.php
@@ -48,7 +48,7 @@ class Test_REST_API extends \PHPUnit\Framework\TestCase {
             'content_hash'     => 'sha256:abc123def456',
             'tx_hash'          => '0xdeadbeef',
             'verification_url' => 'https://daon.network/verify/abc123',
-            'blockchain_url'   => 'https://explorer.daon.network/tx/0xdeadbeef',
+            'blockchain_url'   => 'https://api.daon.network/api/v1/verify/0xdeadbeef',
             'license'          => 'liberation_v1',
             'protected_at'     => '2026-05-01 10:00:00',
             'verified_at'      => '2026-05-01 10:00:05',
@@ -74,7 +74,7 @@ class Test_REST_API extends \PHPUnit\Framework\TestCase {
         $this->assertSame('liberation_v1', $result['license']);
         $this->assertSame('2026-05-01 10:00:00', $result['protected_at']);
         $this->assertSame('https://daon.network/verify/abc123', $result['verification_url']);
-        $this->assertSame('https://explorer.daon.network/tx/0xdeadbeef', $result['blockchain_url']);
+        $this->assertSame('https://api.daon.network/api/v1/verify/0xdeadbeef', $result['blockchain_url']);
     }
 
     public function test_verify_returns_error_for_unprotected_post(): void {

--- a/wordpress-plugin/daon-creator-protection/tests/test-structured-data.php
+++ b/wordpress-plugin/daon-creator-protection/tests/test-structured-data.php
@@ -46,7 +46,7 @@ class Test_Structured_Data extends \PHPUnit\Framework\TestCase {
             'content_hash'     => 'sha256:abc123def456',
             'tx_hash'          => '0xdeadbeef',
             'verification_url' => 'https://daon.network/verify/abc123',
-            'blockchain_url'   => 'https://explorer.daon.network/tx/0xdeadbeef',
+            'blockchain_url'   => 'https://api.daon.network/api/v1/verify/0xdeadbeef',
             'license'          => 'liberation_v1',
             'protected_at'     => '2026-05-01 10:00:00',
             'verified_at'      => '2026-05-01 10:00:05',


### PR DESCRIPTION
Two values that survived three docs sweeps because they live in **code, not prose**.

## A dead host in the shipped WordPress plugin

`wordpress-plugin/.../class-daon-client.php` built a link to `explorer.daon.network` — a host that **has never resolved** — and handed it to WordPress users as the place to view their registration on chain.

That's not a stale doc. That's shipped plugin code rendering a dead link into somebody's admin screen. Now points at the verification endpoint, which exists.

## `@daon/sdk` in the integration demos

Not a published package. The one that exists is `daon-sdk`. A developer copying the demo got a module-resolution error — a better failure than a dead link, but still a broken first five minutes.

## How they were found

By grepping for the **value** rather than the phrasing, after three sweeps that matched wording and kept missing things. Tests carrying the same strings are updated with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EdAzmVtvNSJHgwbKHsiMu